### PR TITLE
RFC: Support multidimensional reconstructions

### DIFF
--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -14,17 +14,8 @@ Use `Reconstruction(s::AbstractVector{T}, D, τ)` to create an instance.
 
 Use `Reconstruction(s::SizedAray{S1, S2}, D, τ)` to create a reconstruction using
 a multi-dimensional timeseries. Note that a reconstruction created this way will
-have `S2*D` total dimensions, a result of each dimension of `s` having `D` delayed
-dimensions.
-
-## Example
-
-```julia
-using StaticArrays
-data = rand(1000,4)
-s = Size(1000,4)(data)
-R = Reconstruction(s, D, τ)
-```
+have `S2*D` total dimensions and *not* `D`, as a result of each dimension of 
+`s` having `D` delayed dimensions.
 
 ## Description
 The ``n``th row of a `Reconstruction` is the `D`-dimensional vector

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -12,6 +12,20 @@ created from a timeseries `s` with `T` type numbers.
 
 Use `Reconstruction(s::AbstractVector{T}, D, τ)` to create an instance.
 
+Use `Reconstruction(s::SizedAray{S1, S2}, D, τ)` to create a reconstruction using
+a multi-dimensional timeseries. Note that a reconstruction created this way will
+have `S2*D` total dimensions, a result of each dimension of `s` having `D` delayed
+dimensions.
+
+## Example
+
+```julia
+using StaticArrays
+data = rand(1000,4)
+s = Size(1000,4)(data)
+R = Reconstruction(s, D, τ)
+```
+
 ## Description
 The ``n``th row of a `Reconstruction` is the `D`-dimensional vector
 ```math

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -48,6 +48,9 @@ end
 Reconstruction(s::AbstractVector{T}, D, τ) where {T} =
 Reconstruction{D, T, τ}(reconstruct(s, Val{D}(), τ))
 
+Reconstruction(s::SizedArray{Tuple{S1, S2}, T, 2, M}, D, τ) where {S1, S2, T, M} =
+    Reconstruction{S2*D, T, τ}(reconstruct(s, Val{D}(), τ))
+
 @inline delay(::Reconstruction{D, T, t}) where {T,D,t} = t
 
 function reconstruct_impl(::Type{Val{D}}) where D
@@ -66,10 +69,29 @@ function reconstruct_impl(::Type{Val{D}}) where D
     end
 end
 
+function reconstructmat_impl(::Type{Val{S2}}, ::Type{Val{D}}) where {S2, D}
+    gens = [:(s[i + $k*τ, $d]) for k=0:D-1 for d=1:S2]
+
+    quote
+        L = size(s,1) - ($(D-1))*τ;
+        T = eltype(s)
+        data = Vector{SVector{$D*$S2, T}}(L)
+        for i in 1:L
+            data[i] = SVector{$D*$S2,T}($(gens...))
+        end
+        V = typeof(s)
+        T = eltype(s)
+        data
+    end
+end
+
 @generated function reconstruct(s::AbstractVector{T}, ::Val{D}, τ) where {D, T}
     reconstruct_impl(Val{D})
 end
 
+@generated function reconstruct(s::SizedArray{Tuple{S1, S2}, T, 2, M}, ::Val{D}, τ) where {S1, S2, T, M, D}
+    reconstructmat_impl(Val{S2}, Val{D})
+end
 
 # Pretty print:
 matname(d::Reconstruction{D, T, τ}) where {D, T, τ} =

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -5,14 +5,14 @@ end
 using Base.Test, StaticArrays
 
 @testset "Reconstruction" begin
-  ds = Systems.towel()
-  data = trajectory(ds, 10000)
-  s = data[:, 1]; N = length(s)
-  @testset "D = $(D), τ = $(τ)" for D in [2,3], τ in [2,3]
+	ds = Systems.towel()
+	data = trajectory(ds, 10000)
+	s = data[:, 1]; N = length(s)
+	@testset "D = $(D), τ = $(τ)" for D in [2,3], τ in [2,3]
 
-    R = Reconstruction(s, D, τ)
+		R = Reconstruction(s, D, τ)
 
-    @test R[(1+τ):end, 1] == R[1:end-τ, 2]
-    @test size(R) == (length(s) - τ*(D - 1), D)
- end
+		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
+		@test size(R) == (length(s) - τ*(D - 1), D)
+	end
 end

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -15,4 +15,16 @@ using Base.Test, StaticArrays
 		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
 		@test size(R) == (length(s) - τ*(D - 1), D)
 	end
+
+    @testset "D = $(D), τ = $(τ), basedim = $(basedim)" for D in [2,3], τ in [2,3], basedim in [2,3]
+
+        si = Matrix(data[:,1:basedim])
+        s = Size(10001,basedim)(si)
+        R = Reconstruction(s, D, τ)
+
+        for dim in 1:basedim
+            @test R[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
+        end
+        @test size(R) == (size(s,1) - τ*(D - 1), D*basedim)
+    end
 end


### PR DESCRIPTION
I don't know if this would be useful to very many other people, but in my field (biomechanics) we often create reconstructions using multiple dimensions (eg $$\mathbf{X} = [ \dot x\ \dot y\ \dot z\ \ddot x\ \ddot y\ \ddot z\ \dot \theta\ \dot \phi\ \dot \psi\ \ddot \theta\ \ddot \phi\ \ddot \psi ]$$ ).

The proposed additions are based on the current reconstruction code, with the important distinction that the input argument is a SizedArray to dispatch on the number of columns and use the (basically) same generated functions used in the current code.

The only gotcha I can think of at the moment is that for the SizedArray reconstruction, the input argument `D` has the same intent as the original code (ie how many delayed dimensions should be added) but since there are `S2` number of columns in the SizedArray, that means that the returned Reconstruction is `S2*D` number of total dimensions, with each original column/dimension in the input data having `D` number of dimensional delays.
I don't see that as a big problem, and obviously wouldn't affect any code creating normal reconstructions from 1D data; this just means that the number of total dimensions of reconstructions created with multi-dimensional data will not equal `D`, which might be confusing since it is *technically* different from reconstructions of 1D data which do have the same number of total dimensions as `D`.

I hope that is not too confusing.