### PR TITLE
add Dataset[range, SVector]

### DIFF
--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -21,6 +21,7 @@ using Base.Test, StaticArrays
 
     @test size(data[1:10,1:2]) == (10,2)
     @test data[1:10,1:2] == Dataset(a[1:10], b[1:10])
+    @test data[SVector{10}(1:10), SVector(1, 2)] == data[1:10, 1:2]
   end
 
   @testset "minmax" begin


### PR DESCRIPTION
With this, any dataset access `data[range, range2]` with whatever `range` (including colon) should instead be done as `data[range, SVector{Int}]` , for absurd increase in performance (100x)