### PR TITLE
Add `mutual_info` option to estimate delay

### DIFF
--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -208,10 +208,13 @@ matname(d::MDReconstruction{DxB, D, B, T, τ}) where {DxB, D, B, T, τ} =
 #####################################################################################
 #                      Estimate Reconstruction Parameters                           #
 #####################################################################################
+using NearestNeighbors
+using Distances: chebyshev
+using SpecialFunctions: digamma
 using LsqFit: curve_fit
 using StatsBase: autocor
 
-export estimate_delay
+export estimate_delay, mutual_info
 
 """
     localextrema(y) -> max_ind, min_ind
@@ -267,6 +270,56 @@ function exponential_decay(c::AbstractVector)
     return decay
 end
 
+function mutual_info(Xm::Vararg{<:AbstractVector,M}; k=1) where M
+    @assert M > 1
+    @assert (size.(Xm,1) .== size(Xm[1],1)) |> prod
+    N = size(Xm[1],1)
+    
+    d = Dataset(Xm...)
+    tree = KDTree(d.data, Chebyshev())
+    
+    n_x_m = zeros(M)
+
+    Xm_sp = zeros(Int, N, M)
+    Xm_revsp = zeros(Int, N, M)
+    for m in 1:M
+        Xm_sp[:,m] .= sortperm(Xm[m]; alg=QuickSort)
+        Xm_revsp[:,m] .= sortperm(sortperm(Xm[m]; alg=QuickSort); alg=QuickSort)
+    end
+
+    I = digamma(k) - (M-1)/k + (M-1)*digamma(N)
+
+    I_itr = zeros(M)
+    # Makes more sense computationally to loop over N rather than M
+    for i in 1:N
+        point = d[i]
+        idxs, dists = knn(tree, point, k+1)
+
+        ϵi = idxs[indmax(dists)]
+        ϵ = abs.(d[ϵi] - point)
+
+        for m in 1:M
+            hb = lb = Xm_revsp[i,m]
+            while abs(Xm[m][Xm_sp[hb,m]] - Xm[m][i]) <= ϵ[m] && hb < N
+                hb += 1
+            end
+            while abs(Xm[m][Xm_sp[lb,m]] - Xm[m][i]) <= ϵ[m] && lb > 1
+                lb -= 1
+            end
+            n_x_m[m] = hb - lb
+        end
+
+        I_itr .+= digamma.(n_x_m)
+    end
+
+    I_itr ./= N
+
+    I -= sum(I_itr)
+
+    return max(0, I)
+end
+
+
 """
     estimate_delay(s, method::String) -> τ
 
@@ -279,8 +332,8 @@ The `method` can be one of the following:
 * `exp_decay` : perform an exponential fit to the `abs.(c)` with `c` the auto-correlation function of `s`.
   Return the exponential decay time `τ` rounded to an integer.
 """
-function estimate_delay(x::AbstractVector, method::String)
-    method ∈ ["first_zero", "first_min", "exp_decay"] || throw(ArgumentError("Unknown method"))
+function estimate_delay(x::AbstractVector, method::String; maxtau=100, k=1)
+    method ∈ ["first_zero", "first_min", "exp_decay", "mutual_inf"] || throw(ArgumentError("Unknown method"))
      if method=="first_zero"
         c = autocor(x, 0:length(x)÷10; demean=true)
         i = 1
@@ -306,12 +359,13 @@ function estimate_delay(x::AbstractVector, method::String)
         τ = exponential_decay(c)
         return round(Int,τ)
     #Need a package that can be precompiled...
-    # elseif method=="mutual_inf"
-    #     m = get_mutual_information(s,s)
-    #     for i=1:length(x)÷10
-    #         n = get_mutual_information(s[1:end-i],s[1+i:end])
-    #         m > n && break
-    #     end
+    elseif method=="mutual_inf"
+        m = mutual_info(x,x; k=k)
+        for i=1:maxtau
+            n = mutual_info(x[1:end-i],x[1+i:end]; k=k)
+            n > m && return i
+            m = n
+        end
     end
 end
 


### PR DESCRIPTION
Here is what I have so far. I wasn't planning on submitting this so soon, so I don't have any tests or anything else. The mutual info function is as fast as I could make it, but that doesn't mean it is very fast.

The mutual_info function is based on [(Kraskov, Stögbauer, & Grassberger, 2004)](https://doi.org/10.1103/PhysRevE.69.066138). I am fairly certain that my code is an accurate representation of their algorithm (I'm getting reasonable numbers back), but it would be nice if somebody else (with a stronger math background) took a look.