### PR TITLE
Improve parametrically constrained varags Dataset

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -138,7 +138,7 @@ function Dataset(v::Vector{<:AbstractArray{T}}) where {T<:Number}
     return Dataset{D, T}(data)
 end
 
-@generated function _dataset(::Val{D}, vecs::Vararg{<:AbstractVector{T}}) where {D, T}
+@generated function _dataset(vecs::Vararg{<:AbstractVector{T},D}) where {D, T}
     gens = [:(vecs[$k][i]) for k=1:D]
 
     quote
@@ -152,8 +152,7 @@ end
 end
 
 function Dataset(vecs::Vararg{<:AbstractVector{T}}) where {T}
-    D = length(vecs)
-    return Dataset(_dataset(Val{D}(), vecs...))
+    return Dataset(_dataset(vecs...))
 end
 
 


### PR DESCRIPTION
The Julia docs allow for extracting the number of args in a varargs method as shown [here](https://docs.julialang.org/en/latest/manual/methods/#Parametrically-constrained-Varargs-methods-1). This removes the need for dispatching on a `Val` type. I don't imagine there is any effect on performance, but this is a more julian code style. 