### PR TITLE
get_deviations, get_state, set_deviations!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v0.10
+
+## TODO
+* Add docstrings to `get_state`, `get_tangent`, `set_state!` and
+  `set_tangent!`.
+* Decide if `state` and `get_state` should be merged into one.
+
+## DONE
+* Created specialized tangent integrator for discrete systems, which is about 10-20% faster. This is a "breaking" change.
+
+* Created functions `get_state`, `get_tangent`, `set_state!` and
+  `set_tangent!` that really return the
+  tangent matrix or the state correctly fro *any* integrator.
+
 # v0.9
 * Theiler window is now part of the `neighborhood` function
 * Methods that estimate parameters for `Reconstruction` have moved back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # v0.10
 
 ## TODO
-* Add docstrings to `get_state`, `get_tangent`, `set_state!` and
-  `set_tangent!`.
+* Add docstrings to `get_state`, `get_deviations`, `set_state!` and
+  `set_deviations!`.
 * Decide if `state` and `get_state` should be merged into one.
 
 ## DONE
 * Created specialized tangent integrator for discrete systems, which is about 10-20% faster. This is a "breaking" change.
 
-* Created functions `get_state`, `get_tangent`, `set_state!` and
-  `set_tangent!` that really return the
+* Created functions `get_state`, `get_deviations`, `set_state!` and
+  `set_deviations!` that really return the
   tangent matrix or the state correctly fro *any* integrator.
 
 # v0.9

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -195,7 +195,25 @@ get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} = integ.u
 get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Vector{<:AbstractVector}} =
     integ.u[1]
 
+function set_state!(
+    integ::ODEIntegrator{Alg, S}, u::AbstractVector, k::Int = 1
+    ) where {Alg, S<:Vector{<:AbstractVector}}
+    integ.u[k] = u
+end
+function set_state!(
+    integ::ODEIntegrator{Alg, S}, u::AbstractVector, k::Int = 1
+    ) where {Alg, S<:AbstractMatrix}
+    integ.u[:, k] .= u
+end
+
 get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} =
     error("It has no tangent dude")
-get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} =
+get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Matrix} =
+    @view integ.u[:, 2:end]
+get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:SMatrix} =
     integ.u[:, 2:end]
+
+set_tangent!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:Matrix} =
+    (integ.u[:, 2:end] .= Q)
+set_tangent!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:SMatrix} =
+    (integ.u = hcat(integ.u[:,1], Q))

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -199,8 +199,10 @@ get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} = integ.u
 get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} = integ.u[:, 1]
 get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Vector{<:AbstractVector}} =
     integ.u[1]
-get_state(integ::ODEIntegrator{Alg, S}, k) where {Alg, S<:Vector{<:AbstractVector}} =
+get_state(integ::ODEIntegrator{Alg, S}, k::Int) where {Alg, S<:Vector{<:AbstractVector}} =
     integ.u[k]
+get_state(integ::ODEIntegrator{Alg, S}, k::Int) where {Alg, S<:AbstractMatrix} =
+    integ.u[:, k]
 
 function set_state!(
     integ::ODEIntegrator{Alg, S}, u::AbstractVector, k::Int = 1

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -55,12 +55,12 @@ end
 function ContinuousDynamicalSystem(
     eom::F, s, p::P, j::JAC, J0::JM; t0 = 0.0, iad = false) where {F, P, JAC, JM}
 
-    if !(typeof(s) <: AbstractVector)
+    if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector in order
-        to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number
+        in order to be able to create the tangent space."))
     end
-    
+
     IIP = isinplace(eom, 4)
     # Ensure that there are only 2 cases: OOP with SVector or IIP with Vector
     # (requirement from ChaosTools)

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -186,3 +186,16 @@ function trajectory(ds::DynamicalSystem, T, u = ds.prob.u0;
     solve!(integ)
     return Dataset(integ.sol.u)
 end
+
+#####################################################################################
+#                                    Get States                                     #
+#####################################################################################
+get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} = integ.u
+get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} = integ.u[:, 1]
+get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Vector{<:AbstractVector}} =
+    integ.u[1]
+
+get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} =
+    error("It has no tangent dude")
+get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} =
+    integ.u[:, 2:end]

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -55,6 +55,12 @@ end
 function ContinuousDynamicalSystem(
     eom::F, s, p::P, j::JAC, J0::JM; t0 = 0.0, iad = false) where {F, P, JAC, JM}
 
+    if !(typeof(s) <: AbstractVector)
+        throw(ArgumentError("
+        The state of a dynamical system *must* be <: AbstractVector in order
+        to be able to create the tangent space."))
+    end
+    
     IIP = isinplace(eom, 4)
     # Ensure that there are only 2 cases: OOP with SVector or IIP with Vector
     # (requirement from ChaosTools)

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -57,15 +57,14 @@ function ContinuousDynamicalSystem(
 
     if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector/Number
-        in order to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number!"))
     end
 
     IIP = isinplace(eom, 4)
     # Ensure that there are only 2 cases: OOP with SVector or IIP with Vector
     # (requirement from ChaosTools)
-    IIP || typeof(eom(s, p, 0)) <: SVector || error(
-    "Equations of motion must return an `SVector` for DynamicalSystems.jl")
+    IIP || typeof(eom(s, p, t0)) <: SVector || error(
+    "Equations of motion must return an `SVector` for out-of-place form!")
     u0 = safe_state_type(Val{IIP}(), s)
 
     prob = ODEProblem(eom, u0, (t0, oftype(t0, Inf)), p)
@@ -200,6 +199,8 @@ get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} = integ.u
 get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractMatrix} = integ.u[:, 1]
 get_state(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Vector{<:AbstractVector}} =
     integ.u[1]
+get_state(integ::ODEIntegrator{Alg, S}, k) where {Alg, S<:Vector{<:AbstractVector}} =
+    integ.u[k]
 
 function set_state!(
     integ::ODEIntegrator{Alg, S}, u::AbstractVector, k::Int = 1
@@ -213,13 +214,13 @@ function set_state!(
 end
 
 get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} =
-    error("It has no tangent dude")
+    error("It isn't a tangent integrator dude/dudete")
 get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Matrix} =
     @view integ.u[:, 2:end]
 get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:SMatrix} =
     integ.u[:, 2:end]
 
 set_deviations!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:Matrix} =
-    (integ.u[:, 2:end] .= Q)
+    (integ.u[:, 2:end] = Q)
 set_deviations!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:SMatrix} =
     (integ.u = hcat(integ.u[:,1], Q))

--- a/src/dynamicalsystem/continuous.jl
+++ b/src/dynamicalsystem/continuous.jl
@@ -212,14 +212,14 @@ function set_state!(
     integ.u[:, k] .= u
 end
 
-get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} =
+get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:AbstractVector} =
     error("It has no tangent dude")
-get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Matrix} =
+get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:Matrix} =
     @view integ.u[:, 2:end]
-get_tangent(integ::ODEIntegrator{Alg, S}) where {Alg, S<:SMatrix} =
+get_deviations(integ::ODEIntegrator{Alg, S}) where {Alg, S<:SMatrix} =
     integ.u[:, 2:end]
 
-set_tangent!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:Matrix} =
+set_deviations!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:Matrix} =
     (integ.u[:, 2:end] .= Q)
-set_tangent!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:SMatrix} =
+set_deviations!(integ::ODEIntegrator{Alg, S}, Q) where {Alg, S<:SMatrix} =
     (integ.u = hcat(integ.u[:,1], Q))

--- a/src/dynamicalsystem/discrete.jl
+++ b/src/dynamicalsystem/discrete.jl
@@ -56,6 +56,11 @@ const DDS = DiscreteDynamicalSystem
 
 function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC, J0::JM; t0::Int = 0) where {F, P, JAC, JM}
+    if !(typeof(s) <: AbstractVector)
+        throw(ArgumentError("
+        The state of a dynamical system *must* be <: AbstractVector in order
+        to be able to create the tangent space."))
+    end 
     prob = MDP(eom, s, p, t0)
     IIP = isinplace(prob)
     S = typeof(state(prob))
@@ -64,6 +69,11 @@ function DiscreteDynamicalSystem(
 end
 function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC; t0::Int = 0)  where {F, P, JAC}
+    if !(typeof(s) <: AbstractVector)
+        throw(ArgumentError("
+        The state of a dynamical system *must* be <: AbstractVector in order
+        to be able to create the tangent space."))
+    end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)
     IIP = isinplace(prob)
@@ -74,6 +84,11 @@ function DiscreteDynamicalSystem(
 end
 function DiscreteDynamicalSystem(
     eom::F, s, p::P; t0::Int = 0) where {F, P}
+    if !(typeof(s) <: AbstractVector)
+        throw(ArgumentError("
+        The state of a dynamical system *must* be <: AbstractVector in order
+        to be able to create the tangent space."))
+    end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)
     IIP = isinplace(prob)

--- a/src/dynamicalsystem/discrete.jl
+++ b/src/dynamicalsystem/discrete.jl
@@ -58,8 +58,7 @@ function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC, J0::JM; t0::Int = 0) where {F, P, JAC, JM}
     if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector/Number
-        in order to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number!"))
     end
     prob = MDP(eom, s, p, t0)
     IIP = isinplace(prob)
@@ -71,8 +70,7 @@ function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC; t0::Int = 0)  where {F, P, JAC}
     if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector/Number
-        in order to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number!"))
     end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)
@@ -86,8 +84,7 @@ function DiscreteDynamicalSystem(
     eom::F, s, p::P; t0::Int = 0) where {F, P}
     if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector/Number
-        in order to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number!"))
     end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)

--- a/src/dynamicalsystem/discrete.jl
+++ b/src/dynamicalsystem/discrete.jl
@@ -56,11 +56,11 @@ const DDS = DiscreteDynamicalSystem
 
 function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC, J0::JM; t0::Int = 0) where {F, P, JAC, JM}
-    if !(typeof(s) <: AbstractVector)
+    if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector in order
-        to be able to create the tangent space."))
-    end 
+        The state of a dynamical system *must* be <: AbstractVector/Number
+        in order to be able to create the tangent space."))
+    end
     prob = MDP(eom, s, p, t0)
     IIP = isinplace(prob)
     S = typeof(state(prob))
@@ -69,10 +69,10 @@ function DiscreteDynamicalSystem(
 end
 function DiscreteDynamicalSystem(
     eom::F, s, p::P, j::JAC; t0::Int = 0)  where {F, P, JAC}
-    if !(typeof(s) <: AbstractVector)
+    if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector in order
-        to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number
+        in order to be able to create the tangent space."))
     end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)
@@ -84,10 +84,10 @@ function DiscreteDynamicalSystem(
 end
 function DiscreteDynamicalSystem(
     eom::F, s, p::P; t0::Int = 0) where {F, P}
-    if !(typeof(s) <: AbstractVector)
+    if !(typeof(s) <: Union{AbstractVector, Number})
         throw(ArgumentError("
-        The state of a dynamical system *must* be <: AbstractVector in order
-        to be able to create the tangent space."))
+        The state of a dynamical system *must* be <: AbstractVector/Number
+        in order to be able to create the tangent space."))
     end
     prob = MDP(eom, s, p, t0)
     S = typeof(prob.u0)

--- a/src/dynamicalsystem/discrete.jl
+++ b/src/dynamicalsystem/discrete.jl
@@ -217,9 +217,6 @@ u_modified!(t::TDI, a) = nothing
 get_deviations(t::TDI) = t.W
 set_deviations!(t::TDI, Q) = (t.W = Q)
 
-get_deviations(t::TDI) = t.W
-set_deviations!(t::TDI, Q) = (t.W = Q)
-
 #####################################################################################
 #                                 Tangent Stepping                                  #
 #####################################################################################

--- a/src/dynamicalsystem/dynamicalsystem.jl
+++ b/src/dynamicalsystem/dynamicalsystem.jl
@@ -6,6 +6,7 @@ export ContinuousDynamicalSystem, DiscreteDynamicalSystem
 export set_parameter!, step!, inittime
 export trajectory
 export integrator, tangent_integrator, parallel_integrator
+export set_state!, get_state, get_deviations, set_deviations!
 
 #######################################################################################
 #                                  DynamicalSystem                                    #
@@ -343,7 +344,22 @@ See [`trajectory`](@ref) for `diff_eq_kwargs`.
 """
 function integrator end
 
+"""
+    get_state(integ [, k = 1])
+Return the state of the integrator, in the sense of the state of the dynamical system.
+
+If the integrator is a [`parallel_integrator`](@ref), passing `k` will return
+the `k`-th state.
+"""
 get_state(integ) = integ.u
+
+"""
+    set_state!(integ, u [, k = 1])
+Set the state of the integrator to `u`, in the sense of the state of the
+dynamical system. Works for any integrator (normal, tangent, parallel).
+
+For parallel integrator, you can choose which state to set (using `k`).
+"""
 set_state!(integ, u) = (integ.u = u)
 
 """
@@ -383,6 +399,22 @@ and each subsequent one being a deviation vector.
 See [`trajectory`](@ref) for `diff_eq_kwargs`.
 """
 function tangent_integrator end
+
+"""
+    get_deviations(tang_integ)
+Return the deviation vectors of the [`tangent_integrator`](@ref) (always returns
+a matrix with columns the vectors).
+"""
+function get_deviations end
+
+"""
+    set_deviations!(tang_integ, Q)
+Set the deviation vectors of the [`tangent_integrator`](@ref) to `Q`, which must
+be a matrix with each column being a deviation vector.
+
+Passing `Q::SMatrix` in the case of out-of-place systems is more performant.
+"""
+function set_deviations end
 
 """
     parallel_integrator(ds::DynamicalSystem, states; diff_eq_kwargs) -> integ

--- a/src/dynamicalsystem/dynamicalsystem.jl
+++ b/src/dynamicalsystem/dynamicalsystem.jl
@@ -343,6 +343,8 @@ See [`trajectory`](@ref) for `diff_eq_kwargs`.
 """
 function integrator end
 
+get_state(integ) = integ.u
+
 """
     tangent_integrator(ds::DynamicalSystem, Q0 | k::Int; u0, t0, diff_eq_kwargs)
 Return an integrator object that evolves in parallel both the system as well

--- a/src/dynamicalsystem/dynamicalsystem.jl
+++ b/src/dynamicalsystem/dynamicalsystem.jl
@@ -144,7 +144,6 @@ set_parameter!(prob, values) = (prob.p .= values)
 set_parameter!(ds::DS, args...) = set_parameter!(ds.prob, args...)
 
 dimension(prob::DEProblem) = length(prob.u0)
-state(integ::DEIntegrator) = integ.u
 hascallback(prob::ODEProblem) = prob.callback != nothing
 inittime(prob::DEProblem) = prob.tspan[1]
 inittime(ds::DS) = inittime(ds.prob)
@@ -345,20 +344,20 @@ See [`trajectory`](@ref) for `diff_eq_kwargs`.
 function integrator end
 
 """
-    get_state(integ [, k = 1])
+    get_state(integ [, i::Int = 1])
 Return the state of the integrator, in the sense of the state of the dynamical system.
 
-If the integrator is a [`parallel_integrator`](@ref), passing `k` will return
-the `k`-th state.
+If the integrator is a [`parallel_integrator`](@ref), passing `i` will return
+the `i`-th state.
 """
 get_state(integ) = integ.u
 
 """
-    set_state!(integ, u [, k = 1])
+    set_state!(integ, u [, k::Int = 1])
 Set the state of the integrator to `u`, in the sense of the state of the
 dynamical system. Works for any integrator (normal, tangent, parallel).
 
-For parallel integrator, you can choose which state to set (using `k`).
+For parallel integrator, you can choose which state to set (using `i`).
 """
 set_state!(integ, u) = (integ.u = u)
 

--- a/src/dynamicalsystem/dynamicalsystem.jl
+++ b/src/dynamicalsystem/dynamicalsystem.jl
@@ -344,6 +344,7 @@ See [`trajectory`](@ref) for `diff_eq_kwargs`.
 function integrator end
 
 get_state(integ) = integ.u
+set_state!(integ, u) = (integ.u = u)
 
 """
     tangent_integrator(ds::DynamicalSystem, Q0 | k::Int; u0, t0, diff_eq_kwargs)

--- a/test/dynsys_tangent.jl
+++ b/test/dynsys_tangent.jl
@@ -21,24 +21,24 @@ PARAMS = [p, ph]
 # minimalistic lyapunov
 function lyapunov_iip(ds::DS, k)
     D = dimension(ds)
-    tode = tangent_integrator(ds, orthonormal(D,k))
+    tode = tangent_integrator2(ds, orthonormal(D,k))
     λ = zeros(k)
     for t in 1:1000
         while tode.t < t
             step!(tode)
         end
         # println("K = $K")
-        Q, R = qr(view(tode.u, :, 2:k+1))
+        Q, R = qr(get_tangent(tode))
         λ .+= log.(abs.(diag(R)))
 
-        view(tode.u, :, 2:k+1) .= Q
+        set_tangent!(tode, Q)
         u_modified!(tode, true)
     end
     λ = λ/tode.t # woooorks
 end
 function lyapunov_oop(ds::DS, k)
     D = dimension(ds)
-    tode = tangent_integrator(ds, orthonormal(D,k))
+    tode = tangent_integrator2(ds, orthonormal(D,k))
     λ = zeros(k)
     ws_idx = SVector{k, Int}(collect(2:k+1))
     for t in 1:1000
@@ -46,10 +46,10 @@ function lyapunov_oop(ds::DS, k)
             step!(tode)
         end
         # println("K = $K")
-        Q, R = qr(tode.u[:, ws_idx])
+        Q, R = qr(get_tangent(tode))
         λ .+= log.(abs.(diag(R)))
 
-        tode.u = hcat(tode.u[:,1], Q)
+        set_tangent!(tode, Q)
         u_modified!(tode, true)
     end
     λ./tode.t # woooorks

--- a/test/dynsys_tangent.jl
+++ b/test/dynsys_tangent.jl
@@ -28,10 +28,10 @@ function lyapunov_iip(ds::DS, k)
             step!(tode)
         end
         # println("K = $K")
-        Q, R = qr(get_tangent(tode))
+        Q, R = qr(get_deviations(tode))
         λ .+= log.(abs.(diag(R)))
 
-        set_tangent!(tode, Q)
+        set_deviations!(tode, Q)
         u_modified!(tode, true)
     end
     λ = λ/tode.t # woooorks
@@ -46,10 +46,10 @@ function lyapunov_oop(ds::DS, k)
             step!(tode)
         end
         # println("K = $K")
-        Q, R = qr(get_tangent(tode))
+        Q, R = qr(get_deviations(tode))
         λ .+= log.(abs.(diag(R)))
 
-        set_tangent!(tode, Q)
+        set_deviations!(tode, Q)
         u_modified!(tode, true)
     end
     λ./tode.t # woooorks

--- a/test/dynsys_types.jl
+++ b/test/dynsys_types.jl
@@ -40,14 +40,14 @@ for i in 1:8
         @test typeof(J) <: (iip ? Matrix : SMatrix)
 
         tinteg = tangent_integrator(ds, orthonormal(dimension(ds), dimension(ds)))
-        tuprev = deepcopy(state(tinteg))
+        tuprev = deepcopy(get_state(tinteg))
         step!(tinteg)
-        @test tuprev != state(tinteg)
+        @test tuprev != get_state(tinteg)
 
         integ = integrator(ds)
-        uprev = deepcopy(state(integ))
+        uprev = deepcopy(get_state(integ))
         step!(integ)
-        @test uprev != state(integ)
+        @test uprev != get_state(integ)
 
         if i < 5
 
@@ -56,18 +56,18 @@ for i in 1:8
                 step!(integ)
             end
 
-            @test state(tinteg)[:, 1] ≈ integ(tt)
+            @test get_state(tinteg) ≈ integ(tt)
         else
-            @test state(tinteg)[:, 1] == state(integ)
+            @test get_state(tinteg) == get_state(integ)
         end
 
         # Currently the in-place version does not work from DiffEq's side:
         if i > 2
             pinteg = parallel_integrator(ds, [INITCOD[sysindx], INITCOD[sysindx]])
-            puprev = deepcopy(state(pinteg))
+            puprev = deepcopy(get_state(pinteg))
             step!(pinteg)
-            @test state(pinteg)[1] == state(pinteg)[2]
-            @test puprev != state(pinteg)
+            @test get_state(pinteg, 1) == get_state(pinteg, 2) == get_state(pinteg)
+            @test puprev != get_state(pinteg)
 
             if i < 5
                 # The below code does not work at the moment because there
@@ -80,19 +80,19 @@ for i in 1:8
                 # @test state(pinteg)[1] ≈ integ(tt)
 
             else
-                @test state(pinteg)[1] == state(integ)
+                @test get_state(pinteg) == get_state(integ)
             end
         else
             pinteg = parallel_integrator(ds, [INITCOD[sysindx], INITCOD[sysindx]])
-            puprev = deepcopy(state(pinteg))
+            puprev = deepcopy(get_state(pinteg))
             step!(pinteg)
-            @test state(pinteg)[:, 1] == state(pinteg)[:, 2]
-            @test puprev != state(pinteg)
+            @test get_state(pinteg, 1) == get_state(pinteg, 2) == get_state(pinteg)
+            @test puprev != get_state(pinteg)
             tt = pinteg.t
             while integ.t < tt
                 step!(integ)
             end
-            @test state(pinteg)[:, 1] ≈ integ(tt)
+            @test get_state(pinteg, 1) ≈ integ(tt)
         end
     end
 end


### PR DESCRIPTION
This PR *finally* completes the FULL envisioned API for `DynamicalSystemsBase`. 

`get_deviations`, `set_deviations!`, `get_state`, `set_state`, etc work for *any* of the 8 possible combinations of systems and *any* of the 3 types of integrators!

Also, it is now NOT possible to have a matrix as the state of a dynamical system.