### PR TITLE
New reconstruction stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
+# v1.0
+
+## Breaking
+
+* Dropped support of Julia versions < 0.7
+* `Reconstruction` does not exist anymore. Instead, `reconstruct` is used in it's
+  place. The function now also always returns a `Dataset`.
+* In the `reconstruct` function, `D` now stands for the number of temporal neighbors
+  which is **one less** than the dimensionality of the reconstructed space.
+
+
+## New Features
+* `reconstruct` creates internally a subtype of `AbstractEmbedding`. These objects
+  can be used as functors to create the `i`-th reconstructed vector on demand.
+
+
+  
 # v0.10
 
 *some of the following changes are breaking*
 
-## TODO
 * `state` function no longer exists and has been merged into `get_state`.
 * Created specialized tangent integrator for discrete systems, which is about
   20% faster. This is a "breaking" change.

--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ IterTools
 NearestNeighbors
 LsqFit 0.3.0
 Distances
+LinearAlgebra

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,7 +5,6 @@ ForwardDiff 0.5
 Requires 0.4.3
 StaticArrays 0.5.0
 StatsBase 0.8.2
-IterTools
 NearestNeighbors
 LsqFit 0.3.0
 Distances

--- a/src/DynamicalSystemsBase.jl
+++ b/src/DynamicalSystemsBase.jl
@@ -5,6 +5,7 @@ Definitions of core system and data types used
 in in the ecosystem of DynamicalSystems.jl
 """
 module DynamicalSystemsBase
+using StaticArrays
 
 include("dataset.jl")
 include("reconstruction.jl")

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -8,7 +8,8 @@ abstract type AbstractDataset{D, T} end
 
 # Size:
 @inline Base.length(d::AbstractDataset) = length(d.data)
-@inline Base.size(d::AbstractDataset{D,T}, i = 1) where {D,T} = (length(d.data), D)[1]
+@inline Base.size(d::AbstractDataset{D,T}) where {D,T} = (length(d.data), D)
+@inline Base.size(d::AbstractDataset, i) = size(d)[i]
 @inline Base.IteratorSize(d::AbstractDataset) = Base.HasLength()
 
 # Itereting interface:

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,4 +1,4 @@
-using StaticArrays, Requires
+using StaticArrays, Requires, LinearAlgebra
 using IterTools: chain
 
 export Dataset, AbstractDataset, minima, maxima
@@ -277,6 +277,6 @@ using LinearAlgebra
 Perform singular value decomposition on the dataset.
 """
 function svd(d::AbstractDataset)
-    F = svdfact(Matrix(d))
+    F = svd(Matrix(d))
     return F[:U], F[:S], F[:Vt]
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,4 +1,4 @@
-using StaticArrays
+using StaticArrays, Requires
 using IterTools: chain
 
 export Dataset, AbstractDataset, minima, maxima
@@ -169,7 +169,7 @@ Base.Matrix(d::AbstractDataset{D,T}) where {D, T} = Matrix{T}(d)
 
 function Dataset(mat::AbstractMatrix{T}) where {T}
     N, D = size(mat)
-    Dataset(reshape(reinterpret(SVector{D,T}, vec(transpose(mat))), (N,))
+    Dataset(reshape(reinterpret(SVector{D,T}, vec(transpose(mat)))), (N,))
 end
 
 #####################################################################################

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,4 +1,4 @@
-using StaticArrays, Requires, LinearAlgebra
+using StaticArrays, LinearAlgebra
 using IterTools: chain
 import Base: ==
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -280,39 +280,3 @@ function svd(d::AbstractDataset)
     F = svdfact(Matrix(d))
     return F[:U], F[:S], F[:Vt]
 end
-#####################################################################################
-#                                    Dataset IO                                     #
-#####################################################################################
-"""
-    read_dataset(file, ::Type{<:Dataset}, delim::Char = '\t'; skipstart = 0)
-Read a `delim`-delimited text file directly into a dataset of dimension `D`
-with numbers of type `T`.
-
-Optionally skip the first `skipstart` rows of the file (that may e.g.
-contain headers).
-
-Call like `read_dataset("file.txt", Dataset{3, Float64})`.
-"""
-function read_dataset(filename, ::Type{Dataset{D, T}}, delim::Char = '\t';
-    skipstart = 0) where {D, T}
-
-    V = SVector{D, T}
-    data = SVector{D, T}[]
-    open(filename) do io
-        for (i, ss) in enumerate(eachline(io))
-            i ≤ skipstart && continue
-            s = split(ss, delim)
-            push!(data, V(ntuple(k -> parse(T, s[k]), Val(D))))
-        end
-    end
-    return Dataset(data)
-end
-
-"""
-    write_dataset(file, dataset::AbstractDataset, delim::Char = '\t'; opts...)
-Write a `dataset` in a `delim`-delimited text file.
-
-`opts` are keyword arguments passed into `writedlm`.
-"""
-write_dataset(f, dataset::AbstractDataset, delim::Char = '\t'; opts...) =
-writedlm(f, dataset.data, delim; opts...)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -20,6 +20,7 @@ abstract type AbstractDataset{D, T} end
 # 1D indexing  over the container elements:
 @inline Base.getindex(d::AbstractDataset, i) = d.data[i]
 @inline Base.lastindex(d::AbstractDataset) = length(d)
+@inline Base.lastindex(d::AbstractDataset, k) = size(d)[k]
 @inline Base.firstindex(d::AbstractDataset) = 1
 
 # 2D indexing exactly like if the dataset was a matrix

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -25,13 +25,13 @@ as a [`Dataset`](@ref).
 Notice that the dimension of the reconstructed space is `D+1`!
 
 ## Description
-If `τ` is an integer, then the ``n``th row of the reconstruction
+If `τ` is an integer, then the ``n``-th row of the reconstruction
 is
 ```math
 (s(n), s(n+\\tau), s(n+2\\tau), \\dots, s(n+(D-1)\\tau))
 ```
 If instead `τ` is a vector of integers, so that `length(τ) == D`,
-then the ``n``th row is
+then the ``n``-th row is
 ```math
 (s(n), s(n+\\tau[1]), s(n+\\tau[2]), \\dots, s(n+\\tau[D]))
 ```

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -1,7 +1,8 @@
+using StaticArrays
 export reconstruct, DelayEmbedding, AbstractEmbedding
 
 #####################################################################################
-#                            Reconstruction Object                                  #
+#                        Delay Embedding Reconstruction                             #
 #####################################################################################
 """
     AbstractEmbedding

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -138,6 +138,7 @@ struct MTDelayEmbedding{D, B, X} <: AbstractEmbedding
     delays::SMatrix{D, B, Int, X} # X = D*B = total dimension number
 end
 
+# notice that here D is the number of temporal neighbors WITHOUT +1 !
 function MTDelayEmbedding(D, τ, B)
     X = (D+1)*B
     if typeof(τ) <: Integer
@@ -149,7 +150,7 @@ function MTDelayEmbedding(D, τ, B)
         ))
         return MTDelayEmbedding{D+1, B, X}(SMatrix{D+1, B, Int, X}(zeros(B)..., τ...))
     else
-	return ArgumentError("Please make sure τ is a Matrix")
+    	throw(ArgumentError("Please make sure τ is a Matrix or an Integer."))
     end
 end
 

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -140,13 +140,15 @@ end
 function MTDelayEmbedding(D, τ, B)
     X = (D+1)*B
     if typeof(τ) <: Integer
-        idxs = SMatrix([k*τ for k in 0:D, j in 1:B]...)
+        idxs = SMatrix{D+1,B,Int,X}([k*τ for k in 0:D, j in 1:B])
         return MTDelayEmbedding{D+1, B, X}(idxs)
-    elseif typeof(τ) <: AbstracMatrix{<:Integer}
+    elseif typeof(τ) <: AbstractMatrix{<:Integer}
         D != size(τ)[1] && throw(ArgumentError(
         "`size(τ)[1]` must equal the number of spatial neighbors."
         ))
         return MTDelayEmbedding{D+1, B, X}(SMatrix{D+1, B, Int, X}(zeros(B)..., τ...))
+    else
+	return ArgumentError("Please make sure τ is a Matrix")
     end
 end
 

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -156,7 +156,7 @@ end
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
     i) where {D, A, B, T, M, X}
 
-    gens = [:(s[i + $(τ[k, d]), $d]) for k=1:D for d=1:B]
+    gens = [:(s[i + r.delays[$k, $d], $d]) for k=1:D for d=1:B]
 
     quote
         @inbounds return SVector{$D*$B,T}($(gens...))

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -150,7 +150,7 @@ function MTDelayEmbedding(D, τ, B)
     end
 end
 
-@generated function (r::MTDelayEmbedding{D, B, Int})(
+@generated function (r::MTDelayEmbedding{D, B, X})(
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
     i) where {D, A, B, T, M, X}
 
@@ -163,7 +163,7 @@ end
 
 function reconstruct(
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
-    D, τ) where {D, A, B, T, M, X}
+    D, τ) where {A, B, T, M}
 
     de = MTDelayEmbedding(D, τ, B)
     L = length(s) - D*maximum(de.delays)

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -9,7 +9,7 @@ export reconstruct, DelayEmbedding, AbstractEmbedding
 Super-type of embedding methods. Use `subtypes(AbstractEmbedding)` for available
 methods.
 """
-abstract type AbstractEmbedding end
+abstract type AbstractEmbedding <: Function end
 
 """
     DelayEmbedding(D, τ) -> `embedding`
@@ -148,7 +148,8 @@ function MTDelayEmbedding(D, τ, B)
         D != size(τ)[1] && throw(ArgumentError(
         "`size(τ)[1]` must equal the number of spatial neighbors."
         ))
-        return MTDelayEmbedding{D+1, B, X}(SMatrix{D+1, B, Int, X}(zeros(B)..., τ...))
+        return MTDelayEmbedding{D+1, B, X}(SMatrix{D+1, B, Int, X}(
+        vcat(zeros(Int, B)', τ)))
     else
     	throw(ArgumentError("Please make sure τ is a Matrix or an Integer."))
     end
@@ -170,7 +171,7 @@ function reconstruct(
     D, τ) where {A, B, T, M}
 
     de = MTDelayEmbedding(D, τ, B)
-    L = length(s) - maximum(de.delays)
+    L = size(s)[1] - maximum(de.delays)
     X = (D+1)*B
     data = Vector{SVector{X, T}}(undef, L)
     @inbounds for i in 1:L

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -17,14 +17,15 @@ export Reconstruction, MDReconstruction
 abstract type AbstractReconstruction{D, T, τ} <: AbstractDataset{D, T} end
 
 """
-    Reconstruction(s::AbstractVector, D, τ) <: AbstractDataset
-`D`-dimensional delay-coordinates reconstruction object with delay `τ`,
-created from a timeseries `s`.
+    reconstruct(s::AbstractVector, D, τ)
+Reconstruct timeseries `s` using delay coordinates embedding with `D`
+temporal neighbors and delay `τ` (integer or vector). Return the result
+as a [`Dataset`](@ref).
 
-Notice that the number of temporal neighbors is `D-1`!
+Notice that the dimension of the reconstructed space is `D+1`!
 
 ## Description
-If `τ` is an integer, then the ``n``th row of a `Reconstruction`
+If `τ` is an integer, then the ``n``th row of the reconstruction
 is
 ```math
 (s(n), s(n+\\tau), s(n+2\\tau), \\dots, s(n+(D-1)\\tau))
@@ -32,16 +33,74 @@ is
 If instead `τ` is a vector of integers, so that `length(τ) == D`,
 then the ``n``th row is
 ```math
-(s(n+\\tau[1]), s(n+\\tau[2]), s(n+\\tau[3]), \\dots, s(n+\\tau[D]))
+(s(n), s(n+\\tau[1]), s(n+\\tau[2]), \\dots, s(n+\\tau[D]))
 ```
 
-The reconstruction object `R` can have same
+The reconstructed dataset can have same
 invariant quantities (like e.g. lyapunov exponents) with the original system
 that the timeseries were recorded from, for proper `D` and `τ` [1, 2].
 
 The case of different delay times allows reconstructing systems with many time scales,
 see [3].
 
+
+## References
+
+[1] : F. Takens, *Detecting Strange Attractors in Turbulence — Dynamical
+Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
+
+[2] : T. Sauer *et al.*, J. Stat. Phys. **65**, pp 579 (1991)
+
+[3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
+"""
+@inline function reconstruct(s::AbstractVector{T}, D::Int, τ::DT) where {T, DT}
+
+    if DT !<: Integer
+        D != length(τ) && throw(ArgumentError(
+        "Delay time vector length must equal the number of spatial neighbors."
+        ))
+    end
+
+    L = reconstructed_length(s, D, τ)
+    r = DelayVector{D, DT}(τ)
+    data = Vector{SVector{D+1, T}}(undef, L)
+    @inbounds for i in 1:L
+        data[i] = r(s, i)
+    end
+    return Dataset{D+1, T}(data)
+end
+
+struct DelayVector{D, TAU}
+    τ::TAU
+end
+
+@generated function (r::DelayVector{D, Int})(s::AbstractArray{T}, i) where {D, T}
+    gens = [:(s[i + $k*r.τ]) for k=0:D]
+    quote
+        @inbounds return SVector{$D,T}($(gens...))
+    end
+end
+@generated function (r::DelayVector{D, Vector{<:Integer}})(s::AbstractArray{T}, i) where {D, T}
+    gens = [:(s[i + r.τ[$k]]) for k=1:D]
+    quote
+        @inline return SVector{$D,T}(s[i], $(gens...))
+    end
+end
+
+reconstructed_length(s, D, τ::Integer) = length(s) - ((D-1))*τ;
+reconstructed_length(s, D, τ::AbstractVector{<:Integer}) = length(s) - ((D-1))*maximum(τ);
+
+
+
+#####################################################################################
+#                              MultiDimensional R                                   #
+#####################################################################################
+struct MDReconstruction{DxB, D, B, T<:Number, τ} <: AbstractReconstruction{DxB, T, τ}
+    data::Vector{SVector{DxB,T}}
+    delay::τ
+end
+
+"""
 ## Multi-dimensional `Reconstruction`
 To make a reconstruction out of a multi-dimensional timeseries (i.e. trajectory) use
 ```julia
@@ -63,65 +122,33 @@ then the ``n``th row is
 Note that a reconstruction created
 this way will have `B*D` total dimensions and *not* `D`, as a result of
 each dimension of `s` having `D` delayed dimensions.
-
-## References
-
-[1] : F. Takens, *Detecting Strange Attractors in Turbulence — Dynamical
-Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
-
-[2] : T. Sauer *et al.*, J. Stat. Phys. **65**, pp 579 (1991)
-
-[3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
 """
-struct Reconstruction{D, T<:Number, TAU}# <: AbstractReconstruction{D, T, τ}
-    data::Vector{SVector{D,T}}
+
+struct MDDelayVector{D, DxB, TAU}
     τ::TAU
 end
 
-Base.summary(d::Reconstruction{D, T}) where {D, T} =
-"(D=$(D), τ=$(d.τ)) - delay coordinates Reconstruction"
+@generated function (r::MDDelayVector{D, Int})(
+    s::AbstractDataset{B, T}, i)
 
-struct Reconstructor{D, TAU}
-    τ::TAU
-end
-
-@generated function (r::Reconstructor{D, Int})(s::AbstractArray{T}, i) where {D, T}
-    gens = [:(Base.unsafe_getindex(s, i + $k*r.τ)) for k=0:D-1]
+    gens = [:(s[i + $k*τ, $d]) for k=0:D-1 for d=1:B]
     quote
-        @inbounds return SVector{$D,T}($(gens...))
+        @inbounds return SVector{$D*B,T}($(gens...))
     end
 end
-@generated function (r::Reconstructor{D, Vector{<:Integer}})(s::AbstractArray{T}, i) where {D, T}
-    gens = [:(Base.unsafe_getindex(s, i + r.τ[$k])) for k=1:D]
+
+
+
+@generated function (r::DelayVector{D, Vector{<:Integer}})(
+    s::SizedArray{Tuple{A, B}, T, 2, M}, i) where {D, A, B, T, M}
+
+    gens = [:(s[i + τ[$k, $d], $d]) for k=1:D for d=1:B]
     quote
-        SVector{$D,T}($(gens...))
+        @inbounds SVector{$D,T}($(gens...))
     end
 end
 
-reconstructed_length(s, D, τ::Integer) = length(s) - ((D-1))*τ;
-reconstructed_length(s, D, τ::AbstractVector{<:Integer}) = length(s) - ((D-1))*maximum(τ);
 
-@inline function delaycoordinates(s::AbstractVector{T}, D::Int, τ::DT) where {T, DT}
-    L = reconstructed_length(s, D, τ)
-    r = Reconstructor{D,DT}(τ)
-    data = Vector{SVector{D, T}}(undef, L)
-    @inbounds for i in 1:L
-        data[i] = r(s, i)
-    end
-    return Reconstruction{D, T, DT}(data, τ)
-end
-
-
-
-
-
-#####################################################################################
-#                              MultiDimensional R                                   #
-#####################################################################################
-struct MDReconstruction{DxB, D, B, T<:Number, τ} <: AbstractReconstruction{DxB, T, τ}
-    data::Vector{SVector{DxB,T}}
-    delay::τ
-end
 
 function reconstructmat_impl(::Val{S2}, ::Val{D}) where {S2, D}
     gens = [:(s[i + $k*τ, $d]) for k=0:D-1 for d=1:S2]

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -168,7 +168,7 @@ function reconstruct(
     D, τ) where {A, B, T, M}
 
     de = MTDelayEmbedding(D, τ, B)
-    L = length(s) - D*maximum(de.delays)
+    L = length(s) - maximum(de.delays)
     X = (D+1)*B
     data = Vector{SVector{X, T}}(undef, L)
     @inbounds for i in 1:L

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -157,7 +157,7 @@ end
     gens = [:(s[i + τ[$k, $d], $d]) for k=1:D for d=1:B]
 
     quote
-        @inbounds return SVector{$D*$B),T}($(gens...))
+        @inbounds return SVector{$D*$B,T}($(gens...))
     end
 end
 

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -140,7 +140,7 @@ end
 function MTDelayEmbedding(D, τ, B)
     X = (D+1)*B
     if typeof(τ) <: Integer
-        idxs = @SMatrix [k*τ for k in 0:D, j in 1:B]
+        idxs = SMatrix([k*τ for k in 0:D, j in 1:B]...)
         return MTDelayEmbedding{D+1, B, X}(idxs)
     elseif typeof(τ) <: AbstracMatrix{<:Integer}
         D != size(τ)[1] && throw(ArgumentError(

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -154,7 +154,7 @@ end
     s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
     i) where {D, A, B, T, M, X}
 
-    gens = [:(s[i + τ[$k, $d], $d]) for k=1:D for d=1:B]
+    gens = [:(s[i + $(τ[k, d]), $d]) for k=1:D for d=1:B]
 
     quote
         @inbounds return SVector{$D*$B,T}($(gens...))

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -1,14 +1,3 @@
-# TODO:
-# separate reconstruction to multidim and standard
-# (since wehave STRec anyway)
-# Clean up source
-# Add tests of type stability when calling the reconstructors
-# Decide on naming: I think Reconstruction should be made normal function,
-# with small letters and renamed to `reconstruct`. The type Reconstruction
-# still stays because I'd prefer to have the pretty printing with τ
-
-
-using StaticArrays
 export reconstruct, DelayEmbedding, AbstractEmbedding
 
 #####################################################################################
@@ -22,12 +11,51 @@ methods.
 abstract type AbstractEmbedding end
 
 """
-    DelayEmbedding(D, τ)
-Return a delay coordiantes embedding method to be used with [`reconstruct`](@ref),
-having `D` temporal neighbors and delay `τ` (integer or vector).
-Notice that the dimension of the reconstructed space will be `D+1`!
+    DelayEmbedding(D, τ) -> `embedding`
+Return a delay coordinates embedding structure to be used as a functor,
+given a timeseries and some index. Calling
+```julia
+embedding(s, n)
+```
+will create the `n`-th reconstructed vector of the embedded space, which has `D`
+temporal neighbors with delay(s) `τ`. See [`reconstruct`](@ref) for more.
 
-This embedding can be used to reconstructed one, or multiple timeseries.
+*Be very careful when choosing `n`, because `@inbounds` is used internally.*
+"""
+struct DelayEmbedding{D} <: AbstractEmbedding
+    # Notice that the type-parameter D here is not the number of temporal neighbors
+    # but plus one. That is because you cannot declare something like
+    # ::SVector{D+1}. It is not allowed.
+    delays::SVector{D, Int}
+end
+
+function DelayEmbedding(D, τ)
+    if typeof(τ) <: Integer
+        idxs = [k*τ for k in 0:D]
+        return DelayEmbedding{D+1}(SVector{D+1, Int}(idxs...))
+    elseif typeof(τ) <: AbstractArray{<:Integer}
+        D != length(τ) && throw(ArgumentError(
+        "Delay time vector length must equal the number of spatial neighbors."
+        ))
+        if !issorted(τ)
+            @warn "Delay times are not sorted. Sorting now."
+            τ = sort(τ)
+        end
+        return DelayEmbedding{D+1}(SVector{D+1, Int}(0, τ...))
+    end
+end
+
+@generated function (r::DelayEmbedding{D})(s::AbstractArray{T}, i) where {D, T}
+    gens = [:(s[i + r.delays[$k]]) for k=1:D]
+    quote
+        @inbounds return SVector{$D,T}($(gens...))
+    end
+end
+
+"""
+    reconstruct(s, D, τ)
+Reconstruct `s` using the delay coordinates embedding with `D` temporal neighbors
+and delay `τ` and return the result as a [`Dataset`](@ref).
 
 ## Description
 ### Single Timeseries
@@ -41,58 +69,44 @@ then the ``n``-th entry is
 (s(n), s(n+\\tau[1]), s(n+\\tau[2]), \\dots, s(n+\\tau[D]))
 ```
 
-The case of different delay times allows reconstructing systems with many time scales,
-see [3].
-
-## References
-
-[3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
-"""
-struct DelayEmbedding{D}
-    delays::SVector{D, Int}
-end
-
-function DelayEmbedding(D, τ)
-    if typeof(τ) <: Integer
-        idxs = [k*τ for k in 1:D]
-        return DelayEmbedding{D}(SVector{D, Int}(idxs...))
-    elseif typeof(τ) <: AbstractArray{<:Integer}
-        D != length(τ) && throw(ArgumentError(
-        "Delay time vector length must equal the number of spatial neighbors."
-        ))
-        if !issorted(τ)
-            @warn "Delay times are not sorted. Sorting now."
-            τ = sort(τ)
-        end
-        return DelayEmbedding{D}(SVector{D, Int}(τ...))
-    end
-end
-
-@generated function (r::DelayEmbedding{D})(s::AbstractArray{T}, i) where {D, T}
-    gens = [:(s[i + r.delays[$k]]) for k=1:D]
-    quote
-        @inbounds return SVector{$D,T}($(gens...))
-    end
-end
-
-"""
-    reconstruct(s, de::AbstractEmbedding)
-Reconstruct `s` using the embedding `de` (any subtype of `AbstractEmbedding`,
-like e.g. [`DelayEmbedding`](@ref)).
-Return the result as a [`Dataset`](@ref). See the documentations of the individual
-embedding methods for what kind of data can be reconstructed.
-
 The reconstructed dataset can have same
 invariant quantities (like e.g. lyapunov exponents) with the original system
 that the timeseries were recorded from, for proper `D` and `τ` [1, 2].
+The case of different delay times allows reconstructing systems with many time scales,
+see [3].
+
+*Notice* - The dimension of the returned dataset is `D+1`!
+
+### Multiple Timeseries
+To make a reconstruction out of a multiple timeseries (i.e. trajectory) the number
+of timeseries must be known by type, so `s` can be either:
+
+    * `s::AbstractDataset{B}`
+    * `s::SizedAray{A, B}`
+
+If the trajectory is for example ``(x, y)`` and `τ` is integer, then the ``n``-th
+entry of the embedded space is
+```math
+(x(n), y(n), x(n+\\tau), y(n+\\tau), \\dots, x(n+D\\tau), y(n+D\\tau))
+```
+If `τ` is an `AbstractMatrix{Int}`, so that `size(τ) == (D, B)`,
+then we have
+```math
+(x(n), y(n), x(n+\\tau[1, 1]), y(n+\\tau[1, 2]), \\dots, x(n+\\tau[D, 1]), y(n+\\tau[D, 2]))
+```
+
+*Notice* - The dimension of the returned dataset is `(D+1)*B`!
 
 ## References
 [1] : F. Takens, *Detecting Strange Attractors in Turbulence — Dynamical
 Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
 
 [2] : T. Sauer *et al.*, J. Stat. Phys. **65**, pp 579 (1991)
+
+[3] : K. Judd & A. Mees, [Physica D **120**, pp 273 (1998)](https://www.sciencedirect.com/science/article/pii/S0167278997001188)
 """
-@inline function reconstruct(s::AbstractVector{T}, de::DelayEmbedding{D}) where {T, D}
+@inline function reconstruct(s::AbstractVector{T}, D, τ) where {T}
+    de = DelayEmbedding(D, τ)
     L = length(s) - D*de.delays[end]
     data = Vector{SVector{D+1, T}}(undef, L)
     @inbounds for i in 1:L
@@ -104,137 +118,59 @@ end
 #####################################################################################
 #                              MultiDimensional R                                   #
 #####################################################################################
-# TODO:
-struct MTDelayEmbedding <: AbstractEmbedding
-    delays::Matrix{Int}
-end
-
-
-struct MDReconstruction{DxB, D, B, T<:Number, τ} <: AbstractReconstruction{DxB, T, τ}
-    data::Vector{SVector{DxB,T}}
-    delay::τ
-end
-
 """
-## Multi-dimensional `Reconstruction`
-To make a reconstruction out of a multi-dimensional timeseries (i.e. trajectory) use
+    MTDelayEmbedding(D, τ, B) -> `embedding`
+Return a delay coordinates embedding structure to be used as a functor,
+given multiple timeseries (`B` in total), either as a [`Dataset`](@ref) or a
+`SizedArray` (see [`reconstruct`](@ref)), and some index.
+Calling
 ```julia
-Reconstruction(tr::SizedAray{A, B}, D, τ)
-Reconstruction(tr::AbstractDataset{B}, D, τ)
+embedding(s, n)
 ```
-with `B` the "base" dimensions.
+will create the `n`-th reconstructed vector of the embedded space, which has `D`
+temporal neighbors with delay(s) `τ`. See [`reconstruct`](@ref) for more.
 
-If the trajectory is for example ``(x, y)``, then the ``n``th row is
-```math
-(x(n), y(n), x(n+\\tau), y(n+\\tau), \\dots, x(n+(D-1)\\tau), y(n+(D-1)\\tau))
-```
-for integer `τ` and if `τ` is an `AbstractMatrix{Int}`, so that `size(τ) == (D, B)`,
-then the ``n``th row is
-```math
-(x(n+\\tau[1, 1]), y(n+\\tau[1, 2]), \\dots, x(n+\\tau[D, 1]), y(n+\\tau[D, 2]))
-```
-
-Note that a reconstruction created
-this way will have `B*D` total dimensions and *not* `D`, as a result of
-each dimension of `s` having `D` delayed dimensions.
+*Be very careful when choosing `n`, because `@inbounds` is used internally.*
 """
-
-struct MDDelayVector{D, DxB, TAU}
-    τ::TAU
+struct MTDelayEmbedding{D, B, X} <: AbstractEmbedding
+    # Again, here D is the number of temporal neighbors *plus one*.
+    delays::SMatrix{D, B, Int, X} # X = D*B = total dimension number
 end
 
-@generated function (r::MDDelayVector{D, Int})(
-    s::AbstractDataset{B, T}, i)
-
-    gens = [:(s[i + $k*τ, $d]) for k=0:D-1 for d=1:B]
-    quote
-        @inbounds return SVector{$D*B,T}($(gens...))
+function MTDelayEmbedding(D, τ, B)
+    X = (D+1)*B
+    if typeof(τ) <: Integer
+        idxs = @SMatrix [k*τ for k in 0:D, j in 1:B]
+        return MTDelayEmbedding{D+1, B, X}(idxs)
+    elseif typeof(τ) <: AbstracMatrix{<:Integer}
+        D != size(τ)[1] && throw(ArgumentError(
+        "`size(τ)[1]` must equal the number of spatial neighbors."
+        ))
+        return MTDelayEmbedding{D+1, B, X}(SMatrix{D+1, B, Int, X}(zeros(B)..., τ...))
     end
 end
 
-
-
-@generated function (r::DelayVector{D, Vector{<:Integer}})(
-    s::SizedArray{Tuple{A, B}, T, 2, M}, i) where {D, A, B, T, M}
+@generated function (r::MTDelayEmbedding{D, B, Int})(
+    s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
+    i) where {D, A, B, T, M, X}
 
     gens = [:(s[i + τ[$k, $d], $d]) for k=1:D for d=1:B]
+
     quote
-        @inbounds SVector{$D,T}($(gens...))
+        @inbounds return SVector{$D*$B),T}($(gens...))
     end
 end
 
+function reconstruct(
+    s::Union{AbstractDataset{B, T}, SizedArray{Tuple{A, B}, T, 2, M}},
+    D, τ) where {D, A, B, T, M, X}
 
-
-function reconstructmat_impl(::Val{S2}, ::Val{D}) where {S2, D}
-    gens = [:(s[i + $k*τ, $d]) for k=0:D-1 for d=1:S2]
-
-    quote
-        L = size(s,1) - ($(D-1))*τ;
-        T = eltype(s)
-        data = Vector{SVector{$D*$S2, T}}(L)
-        for i in 1:L
-            data[i] = SVector{$D*$S2,T}($(gens...))
-        end
-        V = typeof(s)
-        T = eltype(s)
-        data
+    de = MTDelayEmbedding(D, τ, B)
+    L = length(s) - D*maximum(de.delays)
+    X = (D+1)*B
+    data = Vector{SVector{X, T}}(undef, L)
+    @inbounds for i in 1:L
+        data[i] = de(s, i)
     end
+    return Dataset{D+1, T}(data)
 end
-
-@generated function reconstruct(s::SizedArray{Tuple{A, B}, T, 2, M}, ::Val{D}, τ) where {A, B, T, M, D}
-    reconstructmat_impl(Val{B}(), Val{D}())
-end
-@generated function reconstruct(s::AbstractDataset{B, T}, ::Val{D}, τ) where {B, T, D}
-    reconstructmat_impl(Val{B}(), Val{D}())
-end
-
-Reconstruction(s::AbstractDataset{B, T}, D, τ::Int) where {B, T} =
-MDReconstruction{B*D, D, B, T, Int}(reconstruct(s, Val{D}(), τ), τ)
-
-Reconstruction(s::SizedArray{Tuple{A, B}, T, 2, M}, D, τ::Int) where {A, B, T, M} =
-MDReconstruction{B*D, D, B, T, Int}(reconstruct(s, Val{D}(), τ), τ)
-
-## Multi-time version
-function reconstructmat_impl_tvec(::Val{S2}, ::Val{D}) where {S2, D}
-    gens = [:(s[i + τ[$k, $d], $d]) for k=1:D for d=1:S2]
-
-    quote
-        L = size(s,1) - maximum(τ);
-        T = eltype(s)
-        data = Vector{SVector{$D*$S2, T}}(L)
-        for i in 1:L
-            data[i] = SVector{$D*$S2,T}($(gens...))
-        end
-        V = typeof(s)
-        T = eltype(s)
-        data
-    end
-end
-
-@generated function reconstruct_multi(s::SizedArray{Tuple{A, B}, T, 2, M}, ::Val{D}, τ) where {A, B, T, M, D}
-    reconstructmat_impl_tvec(Val{B}(), Val{D}())
-end
-@generated function reconstruct_multi(s::AbstractDataset{B, T}, ::Val{D}, τ) where {B, T, D}
-    reconstructmat_impl_tvec(Val{B}(), Val{D}())
-end
-
-function Reconstruction(
-    s::AbstractDataset{B, T}, D, τ::DT) where {B, T, DT<:AbstractMatrix{Int}}
-    size(τ) != (D, B) && throw(ArgumentError(
-    "The delay matrix must have `size(τ) == (D, B)`."
-    ))
-    return MDReconstruction{B*D, D, B, T, DT}(reconstruct_multi(s, Val{D}(), τ), τ)
-end
-
-function Reconstruction(
-    s::SizedArray{Tuple{A, B}, T, 2, M}, D, τ::DT
-    ) where {A, B, T, M, DT<:AbstractMatrix{Int}}
-    size(τ) != (D, B) && throw(ArgumentError(
-    "The delay matrix must have `size(τ) == (D, B)`."
-    ))
-    return MDReconstruction{B*D, D, B, T, DT}(reconstruct_multi(s, Val{D}(), τ), τ)
-end
-
-# Pretty print:
-Base.summary(d::MDReconstruction{DxB, D, B, T, τ}) where {DxB, D, B, T, τ} =
-"(B=$(B), D=$(D), τ=$(d.delay)) - delay coordinates multi-dimensional Reconstruction"

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -107,7 +107,7 @@ Systems and Turbulence*, Lecture Notes in Mathematics **366**, Springer (1981)
 """
 @inline function reconstruct(s::AbstractVector{T}, D, τ) where {T}
     de = DelayEmbedding(D, τ)
-    L = length(s) - D*de.delays[end]
+    L = length(s) - de.delays[end]
     data = Vector{SVector{D+1, T}}(undef, L)
     @inbounds for i in 1:L
         data[i] = de(s, i)
@@ -172,5 +172,5 @@ function reconstruct(
     @inbounds for i in 1:L
         data[i] = de(s, i)
     end
-    return Dataset{D+1, T}(data)
+    return Dataset{B*(D+1), T}(data)
 end

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -101,7 +101,7 @@ end
 reconstructed_length(s, D, τ::Integer) = length(s) - ((D-1))*τ;
 reconstructed_length(s, D, τ::AbstractVector{<:Integer}) = length(s) - ((D-1))*maximum(τ);
 
-@inline function reconstruct(s::AbstractVector{T}, D::Int, τ::DT) where {T, DT}
+@inline function delaycoordinates(s::AbstractVector{T}, D::Int, τ::DT) where {T, DT}
     L = reconstructed_length(s, D, τ)
     r = Reconstructor{D,DT}(τ)
     data = Vector{SVector{D, T}}(undef, L)

--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -1,11 +1,8 @@
-cd()
 using DynamicalSystemsBase
 using Test, StaticArrays
 
 @testset "Dataset" begin
-  ds = Systems.towel()
-  data = trajectory(ds, 1000)
-
+  data = Dataset(rand(1001,3))
   @testset "Methods & Indexing" begin
     a = data[:, 1]
     b = data[:, 2]

--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -1,8 +1,6 @@
 cd()
-println("\nTesting Dataset (file at $(pwd()))...")
 using DynamicalSystemsBase
 using Test, StaticArrays
-using DynamicalSystemsBase: read_dataset, write_dataset
 
 @testset "Dataset" begin
   ds = Systems.towel()
@@ -37,41 +35,9 @@ using DynamicalSystemsBase: read_dataset, write_dataset
   @testset "Conversions" begin
     m = Matrix(data)
     @test Dataset(m) == data
-    @test reinterpret(Dataset, reinterpret(Matrix, data)) == data
-    @test transpose(m) == reinterpret(Matrix, data)
 
     m = rand(1000, 4)
-    @test reinterpret(Matrix, reinterpret(Dataset, m)) == m
-    @test Dataset(m) !== Dataset(transpose(m))
-    @test Dataset(m) == reinterpret(Dataset, transpose(m))
+    @test Matrix(Dataset(m)) == m
   end
 
-  @testset "IO" begin
-    @test !isfile("test.txt")
-    write_dataset("test.txt", data)
-    @test isfile("test.txt")
-
-    data3 = read_dataset("test.txt", Dataset{3, Float64})
-    @test dimension(data3) == 3
-    @test data3 == data
-
-    data2 = read_dataset("test.txt", Dataset{2, Float64})
-    @test dimension(data2) == 2
-
-    rm("test.txt")
-
-    write_dataset("test.txt", data, ',')
-    @test isfile("test.txt")
-
-    data3 = read_dataset("test.txt", Dataset{3, Float64}, ',')
-    @test dimension(data3) == 3
-    @test data3 == data
-
-    data2 = read_dataset("test.txt", Dataset{2, Float64}, ',')
-    @test dimension(data2) == 2
-
-    rm("test.txt")
-
-    @test !isfile("test.txt") # make extra sure!
-  end
 end

--- a/test/dataset_tests.jl
+++ b/test/dataset_tests.jl
@@ -1,5 +1,6 @@
-using DynamicalSystemsBase
 using Test, StaticArrays
+
+println("\nTesting Dataset...")
 
 @testset "Dataset" begin
   data = Dataset(rand(1001,3))

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -1,40 +1,38 @@
 using DynamicalSystemsBase
 using Test, StaticArrays
 
-println("\nTesting Reconstruction")
+println("\nTesting reconstruct")
 
-ds = Systems.towel()
-data = trajectory(ds, 10000)
+data = Dataset(rand(10001,3))
 s = data[:, 1]; N = length(s)
 
-@testset "Reconstruction" begin
+@testset "reconstruct" begin
 
-	@testset "D = $(D), τ = $(τ)" for D in [2,3], τ in [2,3]
+	@testset "D = $(D), τ = $(τ)" for D in [1,2], τ in [2,3]
 
-		R = Reconstruction(s, D, τ)
+		R = reconstruct(s, D, τ)
 
 		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
-		@test size(R) == (length(s) - τ*(D - 1), D)
+		@test size(R) == (length(s) - τ*D, D+1)
 	end
 end
 
-@testset "Multi-time R" begin
+@testset "Multi-time reconstruct" begin
 
     D = 2
-    τ1 = [0, 2]
-    τ2 = [2, 4]
+    τ1 = [2, 4]
+    τ2 = [4, 8]
 
-    R0 = Reconstruction(s, D, 2)
-    R1 = Reconstruction(s, D, τ1)
-    R2 = Reconstruction(s, D, τ2)
+    R0 = reconstruct(s, D, 2)
+    R1 = reconstruct(s, D, τ1)
+    R2 = reconstruct(s, D, τ2)
 
     @test R1 == R0
 
-    R2x = R2[:, 1]
-    @test R2[:, 1] == R0[3:end, 1]
-    @test R2[:, 2] == R0[3:end, 2]
-    @test R2.delay[1] == 2
-    @test size(R2) == (N-4, 2)
+    R2y = R2[:, 2]
+    @test R2y == R0[5:end, 1]
+    @test R2[:, 1] == R0[1:end-4, 1]
+    @test size(R2) == (N-maximum(τ2), 3)
 
 end
 
@@ -43,9 +41,9 @@ end
 
         si = Matrix(data[:,1:basedim])
         s = Size(10001,basedim)(si)
-        R = Reconstruction(s, D, τ)
+        R = reconstruct(s, D, τ)
         tr = Dataset(si)
-        R2 = Reconstruction(tr, D, τ)
+        R2 = reconstruct(tr, D, τ)
 
         for dim in 1:basedim
             @test R[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
@@ -61,8 +59,8 @@ end
     taus = [0 0; 2 3; 4 6; 6 8]
     data2 = data[:, 1:2]
     data3 = Size(10001, 2)(Matrix(data2))
-    R1 = Reconstruction(data2, 4, taus)
-    R2 = Reconstruction(data3, 4, taus)
+    R1 = reconstruct(data2, 4, taus)
+    R2 = reconstruct(data3, 4, taus)
 
     @test R1 == R2
     @test R1[:, 1] == data2[1:end-8, 1]
@@ -72,7 +70,7 @@ end
     # test error throws:
     taus = [0 0 0; 2 3 0; 4 6 0; 6 8 0]
     try
-        R1 = Reconstruction(data2, 4, taus)
+        R1 = reconstruct(data2, 4, taus)
     catch err
         @test isa(err, ArgumentError)
         @test contains(err.msg, "delay matrix")

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -37,20 +37,22 @@ end
 end
 
 @testset "Multidim R" begin
-    @testset "D = $(D), τ = $(τ), base = $(basedim)" for     D in [2,3], τ in [2,3], basedim in [2,3]
+    @testset "D = $(D), B = $(basedim)" for  D in [2,3], basedim in [2,3]
 
+        τ = 3
         si = Matrix(data[:,1:basedim])
-        s = Size(10001,basedim)(si)
-        R = reconstruct(s, D, τ)
+        sizedsi = Size(N,basedim)(si)
+        R = reconstruct(sizedsi, D, τ)
         tr = Dataset(si)
         R2 = reconstruct(tr, D, τ)
+
+        @test R == R2
 
         for dim in 1:basedim
             @test R[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
             @test R2[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
         end
-        @test size(R) == (size(s,1) - τ*(D - 1), D*basedim)
-        @test size(R2) == (size(s,1) - τ*(D - 1), D*basedim)
+        @test size(R) == (size(s,1) - τ*D, (D+1)*basedim)
     end
 end
 
@@ -69,11 +71,6 @@ end
 
     # test error throws:
     taus = [0 0 0; 2 3 0; 4 6 0; 6 8 0]
-    try
-        R1 = reconstruct(data2, 4, taus)
-    catch err
-        @test isa(err, ArgumentError)
-        @test contains(err.msg, "delay matrix")
-    end
+    @test_throws ArgumentError reconstruct(data2, 4, taus)
 
 end

--- a/test/reconstruction_tests.jl
+++ b/test/reconstruction_tests.jl
@@ -1,76 +1,78 @@
-using DynamicalSystemsBase
 using Test, StaticArrays
 
 println("\nTesting reconstruct")
 
-data = Dataset(rand(10001,3))
-s = data[:, 1]; N = length(s)
-
 @testset "reconstruct" begin
 
-	@testset "D = $(D), τ = $(τ)" for D in [1,2], τ in [2,3]
+    data = Dataset(rand(10001,3))
+    s = data[:, 1]; N = length(s)
 
-		R = reconstruct(s, D, τ)
+    @testset "standard" begin
 
-		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
-		@test size(R) == (length(s) - τ*D, D+1)
-	end
-end
+    	@testset "D = $(D), τ = $(τ)" for D in [1,2], τ in [2,3]
 
-@testset "Multi-time reconstruct" begin
+    		R = reconstruct(s, D, τ)
 
-    D = 2
-    τ1 = [2, 4]
-    τ2 = [4, 8]
-
-    R0 = reconstruct(s, D, 2)
-    R1 = reconstruct(s, D, τ1)
-    R2 = reconstruct(s, D, τ2)
-
-    @test R1 == R0
-
-    R2y = R2[:, 2]
-    @test R2y == R0[5:end, 1]
-    @test R2[:, 1] == R0[1:end-4, 1]
-    @test size(R2) == (N-maximum(τ2), 3)
-
-end
-
-@testset "Multidim R" begin
-    @testset "D = $(D), B = $(basedim)" for  D in [2,3], basedim in [2,3]
-
-        τ = 3
-        si = Matrix(data[:,1:basedim])
-        sizedsi = Size(N,basedim)(si)
-        R = reconstruct(sizedsi, D, τ)
-        tr = Dataset(si)
-        R2 = reconstruct(tr, D, τ)
-
-        @test R == R2
-
-        for dim in 1:basedim
-            @test R[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
-            @test R2[(1+τ):end, dim] == R[1:end-τ, dim+basedim]
-        end
-        @test size(R) == (size(s,1) - τ*D, (D+1)*basedim)
+    		@test R[(1+τ):end, 1] == R[1:end-τ, 2]
+    		@test size(R) == (length(s) - τ*D, D+1)
+    	end
     end
-end
 
-@testset "Multidim Multi-time" begin
+    @testset "multi-time" begin
 
-    taus = [0 0; 2 3; 4 6; 6 8]
-    data2 = data[:, 1:2]
-    data3 = Size(10001, 2)(Matrix(data2))
-    R1 = reconstruct(data2, 4, taus)
-    R2 = reconstruct(data3, 4, taus)
+        D = 2
+        τ1 = [2, 4]
+        τ2 = [4, 8]
 
-    @test R1 == R2
-    @test R1[:, 1] == data2[1:end-8, 1]
-    @test R1[:, 2] == data2[1:end-8, 2]
-    @test R1[:, 3] == data2[3:end-6, 1]
+        R0 = reconstruct(s, D, 2)
+        R1 = reconstruct(s, D, τ1)
+        R2 = reconstruct(s, D, τ2)
 
-    # test error throws:
-    taus = [0 0 0; 2 3 0; 4 6 0; 6 8 0]
-    @test_throws ArgumentError reconstruct(data2, 4, taus)
+        @test R1 == R0
 
+        R2y = R2[:, 2]
+        @test R2y == R0[5:end, 1]
+        @test R2[:, 1] == R0[1:end-4, 1]
+        @test size(R2) == (N-maximum(τ2), 3)
+
+    end
+
+    @testset "multidim " begin
+        @testset "D = $(D), B = $(B)" for  D in [2,3], B in [2,3]
+
+            τ = 3
+            si = Matrix(data[:,1:B])
+            sizedsi = Size(N,B)(si)
+            R = reconstruct(sizedsi, D, τ)
+            tr = Dataset(si)
+            R2 = reconstruct(tr, D, τ)
+
+            @test R == R2
+
+            for dim in 1:B
+                @test R[(1+τ):end, dim] == R[1:end-τ, dim+B]
+                @test R2[(1+τ):end, dim] == R[1:end-τ, dim+B]
+            end
+            @test size(R) == (size(s,1) - τ*D, (D+1)*B)
+        end
+    end
+
+    @testset "multidim multi-time" begin
+
+        taus = [2 3; 4 6; 6 8]
+        data2 = data[:, 1:2]
+        data3 = Size(N, 2)(Matrix(data2))
+        R1 = reconstruct(data2, 3, taus)
+        R2 = reconstruct(data3, 3, taus)
+
+        @test R1 == R2
+        @test R1[:, 1] == data2[1:end-8, 1]
+        @test R1[:, 2] == data2[1:end-8, 2]
+        @test R1[:, 3] == data2[3:end-6, 1]
+
+        # test error throws:
+        taus = [0 0 0; 2 3 0; 4 6 0; 6 8 0]
+        @test_throws ArgumentError reconstruct(data2, 4, taus)
+
+    end
 end


### PR DESCRIPTION
This PR re-works the *entirety* of the reconstruction, after like 5 iterations of designs.

* The top level function is now named `reconstruct`
* it returns a `Dataset` instead. `Reconstruction` is _no more_
* In the top level calls `D` now represents the amount of temporal neighbors, so that the returned dataset has `D+1` dimension
* Two low-level (but easy to use) structs have been created in order to be possible to reconstruct any arbitrary vector of the reconstructed space - on demand.
* The PR also updates `Dataset` to 0.7. I think at least, still haven't updated the test files!

Still todo:

- [x] update changelog
- [x] tests
- [x] test it in a real scenario. I am sure some god damned `D` that should be `D+1` is hiding somewhere

@JonasIsensee this is your first review ever, have fun. (Also, you do the rest of the to-dos because I re-wrote this piece of code at least 20 times)