### PR TITLE
New internalnorm based on state only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog of `DynamicalSystemsBase`.
 
+# v1.3
+* The specialized integrators (tangent & parallel) now implement an internal norm that only evaluates norm of the main state, instead of using the other parallel states or deviation vectors. (#86)
+* Bunch of bugfixes and performance improvements (see git history)
+
 # v1.2
 In version `1.2` we have moved to `DiffEqBase 5.0+`. In addition to that we have changed the default integrator to `SimpleATsit5` from module `SimpleDiffEq`. This is not a breaking change and you can use any of the previous integrators. **It must be stated though that numeric results you obtained using the default integrator will now be slightly different**.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "1.2.5"
+version = "1.3.0"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"
@@ -15,12 +15,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DiffEqBase = "5.0.0"
+DiffEqBase = "5.10.0"
 DiffEqCallbacks = "≥ 2.1.0"
 ForwardDiff = "≥ 0.8.0"
 OrdinaryDiffEq = "≥ 5.0.0"
 Reexport = "≥ 0.1.0"
-SimpleDiffEq = "≥ 0.3.0"
+SimpleDiffEq = "≥ 0.4.0"
 StaticArrays = "≥ 0.8.0"
 julia = "≥ 1.0.0"
 

--- a/test/dynsys_types.jl
+++ b/test/dynsys_types.jl
@@ -66,7 +66,7 @@ for i in 1:8
 
         # Currently the in-place version does not work from DiffEq's side:
         if i > 2
-            pinteg = parallel_integrator(ds, [INITCOD[sysindx], INITCOD[sysindx]]; alg = alg)
+            pinteg = parallel_integrator(ds, [copy(INITCOD[sysindx]), copy(INITCOD[sysindx])]; alg = alg)
             puprev = deepcopy(get_state(pinteg))
             step!(pinteg)
             @test get_state(pinteg, 1) == get_state(pinteg, 2) == get_state(pinteg)

--- a/test/norm_tests.jl
+++ b/test/norm_tests.jl
@@ -1,0 +1,44 @@
+using DynamicalSystemsBase, SimpleDiffEq, DiffEqBase
+using Statistics, Test
+
+ds = Systems.lorenz()
+ALG = SimpleATsit5()
+
+# %%
+
+i1 = tangent_integrator(ds, 3; alg = ALG)
+i2 = tangent_integrator(ds, 3; alg = ALG,
+internalnorm = DiffEqBase.ODE_DEFAULT_NORM)
+
+step!(i1)
+step!(i2)
+dts = zeros(2, 500)
+for i in 1:500
+    step!(i1); step!(i2)
+    dts[:, i] .= (i1.dt, i2.dt)
+end
+
+dt1 = mean(dts[1, :])
+dt2 = mean(dts[2, :])
+
+@test dt1 > dt2
+
+# %%
+s = [get_state(ds), get_state(ds) .+ rand(3)]
+i1 = parallel_integrator(ds, deepcopy(s);
+alg = ALG, internalnorm = DiffEqBase.ODE_DEFAULT_NORM)
+i2 = parallel_integrator(ds, deepcopy(s);
+alg = ALG)
+
+step!(i1)
+step!(i2)
+dts = zeros(2, 1000)
+for i in 1:1000
+    step!(i1); step!(i2)
+    dts[:, i] .= (i1.dt, i2.dt)
+end
+
+dt1 = mean(dts[1, :])
+dt2 = mean(dts[2, :])
+
+@test dt2 > dt1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ include("dynsys_inference.jl")
 include("continuous_systems.jl")
 include("discrete_systems.jl")
 include("integrators_with_callbacks.jl")
+include("norm_tests.jl")
 
 ti = time() - ti
 println("\nTest took total time of:")


### PR DESCRIPTION
Based on the advances of https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/569 this PR implements `internalnorm` for both tangent and parallel integrators, so that the error is evaluated only on the central state of the dynamical system.