### PR TITLE
iip map iteration:  copy input vector to avoid static binding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "1.8.5"
+version = "1.8.8"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/core/discrete.jl
+++ b/src/core/discrete.jl
@@ -21,8 +21,8 @@ stateeltype(::MDI{IIP, S}) where {IIP, S} = eltype(S)
 stateeltype(::MDI{IIP, S}) where {IIP, S<:Vector{<:AbstractArray{T}}} where {T} = T
 
 function reinit!(integ::MDI, u = integ.u, Q0 = nothing; t0 = integ.t0)
-    integ.u = u
-    integ.dummy = u
+    integ.u = copy(u)
+    integ.dummy = copy(u)
     integ.t = t0
     if Q0 != nothing
         set_deviations!(integ, Q0)


### PR DESCRIPTION
Seems that in some situation there is a confusion between the state and the next iteration for iip maps. 