### PR TITLE
Using the "uncoupled" Kuramoto version to improve speed.

### DIFF
--- a/src/predefined/continuous_famous_systems.jl
+++ b/src/predefined/continuous_famous_systems.jl
@@ -989,9 +989,9 @@ end
 function kuramoto_f(du, u, p, t)
     ω = p.ω; K = p.K
     D = length(u)
-    k = K/D
+    z = mean(exp(im .* u))/D
     @inbounds for i in 1:D
-        du[i] = ω[i] + k*sum(sin(u[j] - u[i]) for j in 1:D)
+        du[i] = ω[i] + K*abs(z)*sin(angle(z) - u[i])
     end
     return
 end


### PR DESCRIPTION
This trick that uses the mean field allows to skip a lot of sums: 

```
N = 400
ω = range(-10,10,length = N)
kn = Systems.kuramoto(N; K = 0.1, ω = ω)
T = 40
# PR version
@btime t1 = trajectory(kn, T)
24.202 ms (32202 allocations: 41.37 MiB)

# REP vesion
@btime t1 = trajectory(kn, T)
928.680 ms (31661 allocations: 38.01 MiB)

```