### PR TITLE
small fix in Kuramoto Eqs.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "2.3.8"
+version = "2.3.9"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/predefined/continuous_famous_systems.jl
+++ b/src/predefined/continuous_famous_systems.jl
@@ -991,7 +991,7 @@ using Statistics: mean
 function kuramoto_f(du, u, p, t)
     ω = p.ω; K = p.K
     D = length(u)
-    z = mean(exp.(im .* u))/D
+    z = mean(exp.(im .* u))
     θ = angle(z)
     @inbounds for i in 1:D
         du[i] = ω[i] + K*abs(z)*sin(θ - u[i])


### PR DESCRIPTION
To be sure: 

```
using DynamicalSystems
using BenchmarkTools

# Original equations
function kuramoto_f2!(du, u, p, t)
    ω = p[2]; K = p[1]
    D = length(u)
    k = K/D
    @inbounds for i in 1:D
        du[i] = ω[i] + k*sum(sin(u[j] - u[i]) for j in 1:D)
    end
    return
end

D = 10
K = 3.3; ω = range(-1, 1; length = D)
u0 = rand(D)
# PR Version 
ds1 = Systems.kuramoto(D; K = K, ω = ω)
@btime sol1 = trajectory(ds1, 200, u0)
sol1 = trajectory(ds1, 200, u0)

# Original equations
ds2 = ContinuousDynamicalSystem(kuramoto_f2!, u0, [K, ω])
@btime sol2 = trajectory(ds2, 200, u0)
sol2 = trajectory(ds2, 200, u0)

@assert sum(abs.(sol1[end]- sol2[end])) < 1e-8
```

Results are: 
PR:   6.746 ms (161000 allocations: 9.74 MiB)
Original:   8.318 ms (210000 allocations: 10.23 MiB)
sum(abs.(sol1[end]- sol2[end])) = 6.391054352405945e-12

The performance gain is not that clear. But using directly `DifferentialEquations.jl` the Benchmarks falls to 2ms. 



