### PR TITLE
Allow keyword propagation in trajectory

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/advanced_integrators/projected_integrator.jl
+++ b/src/advanced_integrators/projected_integrator.jl
@@ -48,7 +48,7 @@ projection(u) = [sum(u), sqrt(u[1]^2 + u[2]^2)]
 complete_state(y) = repeat(y[1]/5, 5)
 pinteg = # same as in above example...
 """
-function projected_integrator(ds::DynamicalSystem, projection, complete_state;
+function projected_integrator(ds::GeneralizedDynamicalSystem, projection, complete_state;
         u0 = get_state(ds), diffeq = NamedTuple()
 	)
     if projection isa AbstractVector{Int}
@@ -86,7 +86,8 @@ isdiscretetime(p::ProjectedIntegrator) = isdiscretetime(p.integ)
 DelayEmbeddings.dimension(::ProjectedIntegrator{P, PD}) where {P, PD} = PD
 
 
-integrator(p::ProjectedIntegrator) = p
+integrator(pinteg::ProjectedIntegrator, args...; kwargs...) = pinteg
+#integrator(p::ProjectedIntegrator) = p
 get_state(pinteg::ProjectedIntegrator{<:Function}) =
     pinteg.projection(get_state(pinteg.integ))
 get_state(pinteg::ProjectedIntegrator{<:SVector}) =
@@ -125,4 +126,3 @@ function (pinteg::ProjectedIntegrator{P})(t)  where {P}
         return u[pinteg.projection]
     end
 end
-integrator(pinteg::ProjectedIntegrator, args...; kwargs...) = pinteg

--- a/src/advanced_integrators/stroboscopic_map.jl
+++ b/src/advanced_integrators/stroboscopic_map.jl
@@ -57,6 +57,6 @@ end
 
 current_time(smap::StroboscopicMap) = current_time(smap.integ)
 function (smap::StroboscopicMap)(t)
-    return pinteg.integ(t)
+    error("Time interpolation is not possible for a stroboscopic map!")
 end
 integrator(pinteg::StroboscopicMap, args...; kwargs...) = pinteg

--- a/src/advanced_integrators/stroboscopic_map.jl
+++ b/src/advanced_integrators/stroboscopic_map.jl
@@ -38,7 +38,7 @@ function step!(smap::StroboscopicMap)
 	return smap.integ.u
 end
 function step!(smap::StroboscopicMap, n::Int)
-	step!(smap.integ, n*smap.T, true)
+	for k in 1:n; step!(smap.integ, smap.T, true); end
 	return smap.integ.u
 end
 function reinit!(smap::StroboscopicMap, u0)

--- a/src/advanced_integrators/stroboscopic_map.jl
+++ b/src/advanced_integrators/stroboscopic_map.jl
@@ -57,6 +57,10 @@ end
 
 current_time(smap::StroboscopicMap) = current_time(smap.integ)
 function (smap::StroboscopicMap)(t)
-    error("Time interpolation is not possible for a stroboscopic map!")
+	if t == current_time(smap)
+		return get_state(smap)
+	else
+		error("Can't extrapolate discrete systems!")
+	end
 end
 integrator(pinteg::StroboscopicMap, args...; kwargs...) = pinteg

--- a/src/core/api_docstrings.jl
+++ b/src/core/api_docstrings.jl
@@ -148,7 +148,13 @@ You can also choose any other solver except `SimpleATsit5`, such as `Tsit5`, as 
 as you turn off adaptive stepping, e.g.
 `(alg = Tsit5(), adaptive = false, dt = your_step_size)`.
 """
-function trajectory end
+function trajectory(integ, args...; kwargs...)
+  if isdiscretetime(integ)
+      return trajectory_discrete(integ, args...; kwargs...)
+  else
+      return trajectory_continuous(integ, args...; kwargs...)
+  end
+end
 
 
 """

--- a/src/core/continuous.jl
+++ b/src/core/continuous.jl
@@ -190,7 +190,7 @@ end
 function trajectory_continuous(integ, T, u0 = nothing;
         Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, kwargs...)
     !isnothing(u0) && reinit!(integ, u0)
-    # This hack is to get type-stable `D`` from integrator
+    # This hack is to get type-stable `D` from integrator
     # (ODEIntegrator doesn't have `D` as type parameter)
     D = isnothing(dimvector) ? dimension(integ) : length(dimvector)
     t0 = current_time(integ)

--- a/src/core/continuous.jl
+++ b/src/core/continuous.jl
@@ -188,7 +188,7 @@ function trajectory(ds::ContinuousDynamicalSystem, T, u = ds.u0;
 end
 
 function trajectory_continuous(integ, T, u0 = nothing;
-        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing
+        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, kwargs...
     )
     !isnothing(u0) && reinit!(integ, u0)
     # This hack is to get type-stable `D`` from integrator

--- a/src/core/continuous.jl
+++ b/src/core/continuous.jl
@@ -188,7 +188,7 @@ function trajectory(ds::ContinuousDynamicalSystem, T, u = ds.u0;
 end
 
 function trajectory_continuous(integ, T, u0 = nothing;
-        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, kwargs...)
+        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, diffeq=nothing)
     !isnothing(u0) && reinit!(integ, u0)
     # This hack is to get type-stable `D` from integrator
     # (ODEIntegrator doesn't have `D` as type parameter)

--- a/src/core/continuous.jl
+++ b/src/core/continuous.jl
@@ -188,8 +188,7 @@ function trajectory(ds::ContinuousDynamicalSystem, T, u = ds.u0;
 end
 
 function trajectory_continuous(integ, T, u0 = nothing;
-        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, kwargs...
-    )
+        Δt = 0.01, Ttr = 0.0, sv_acc=nothing, dimvector = nothing, kwargs...)
     !isnothing(u0) && reinit!(integ, u0)
     # This hack is to get type-stable `D`` from integrator
     # (ODEIntegrator doesn't have `D` as type parameter)

--- a/src/core/discrete.jl
+++ b/src/core/discrete.jl
@@ -266,7 +266,7 @@ end
 
 # This version of trajectory is for any discrete integrator: Poincare map,
 # stroboscopic map, or standard MinimalDiscreteIntegrator.
-function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing)
+function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing, kwargs...)
     !isnothing(u0) && reinit!(integ, u0)
     Δt = round(Int, Δt)
     T = eltype(get_state(integ))

--- a/src/core/discrete.jl
+++ b/src/core/discrete.jl
@@ -257,7 +257,7 @@ end
 
 # This version of trajectory is for any discrete integrator: Poincare map,
 # stroboscopic map, or standard MinimalDiscreteIntegrator.
-function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing, kwargs...)
+function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing, diffeq=nothing)
     !isnothing(u0) && reinit!(integ, u0)
     Δt = round(Int, Δt)
     T = eltype(get_state(integ))

--- a/src/core/discrete.jl
+++ b/src/core/discrete.jl
@@ -255,15 +255,6 @@ function trajectory(
     trajectory(integ, t; Δt, Ttr, a)
 end
 
-# generic dispatch
-function trajectory(integ, args...; kwargs...)
-    if isdiscretetime(integ)
-        return trajectory_discrete(integ, args...; kwargs...)
-    else
-        return trajectory_continuous(integ, args...; kwargs...)
-    end
-end
-
 # This version of trajectory is for any discrete integrator: Poincare map,
 # stroboscopic map, or standard MinimalDiscreteIntegrator.
 function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing, kwargs...)


### PR DESCRIPTION
The change is needed to avoid an error caused by the `AttractorsViaFeaturizing` method. When the dynamical system is a strob map or a projected system the method `trajectory` throws an error since the `diffeq` keyword is not included in the list. 