### PR TITLE
Enforce `Δt::Int` in discrete trajectory; fix `set_parameter!` for generalized ds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.7.2
+- Integer Δt is now enforced in trajectory calculation of discrete systems. Not doing so led to silently incorrect behavior that the user wouldn't expect.
+- Fixed `set_parameter!` not working for `projected_integrator`.
+
 # v2.7
 * New function `get_states` that returns an iterator over states contained in a `parallel_integrator`.
 # v2.6

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "2.7.0"
+version = "2.7.2"
 
 [deps]
 DelayEmbeddings = "5732040d-69e3-5649-938a-b6b4f237613f"

--- a/src/core/api_docstrings.jl
+++ b/src/core/api_docstrings.jl
@@ -151,11 +151,11 @@ adaptive time-stepping. Use `(alg = SimpleTsit5(), dt = your_step_size)` as keyw
 for a non-adaptive time stepping solver.
 """
 function trajectory(integ, args...; kwargs...)
-  if isdiscretetime(integ)
-      return trajectory_discrete(integ, args...; kwargs...)
-  else
-      return trajectory_continuous(integ, args...; kwargs...)
-  end
+    if isdiscretetime(integ)
+        return trajectory_discrete(integ, args...; kwargs...)
+    else
+        return trajectory_continuous(integ, args...; kwargs...)
+    end
 end
 
 

--- a/src/core/discrete.jl
+++ b/src/core/discrete.jl
@@ -257,7 +257,9 @@ end
 
 # This version of trajectory is for any discrete integrator: Poincare map,
 # stroboscopic map, or standard MinimalDiscreteIntegrator.
-function trajectory_discrete(integ, t, u0 = nothing; Δt=1, Ttr=0, a=nothing, diffeq=nothing)
+function trajectory_discrete(integ, t, u0 = nothing;
+        Δt::Int = 1, Ttr = 0, a = nothing, diffeq = nothing
+    )
     !isnothing(u0) && reinit!(integ, u0)
     Δt = round(Int, Δt)
     T = eltype(get_state(integ))

--- a/src/core/dynamicalsystem.jl
+++ b/src/core/dynamicalsystem.jl
@@ -182,15 +182,20 @@ In this case do `p .= values` (which only works for abstract array `p`).
 
 The same function also works for any integrator.
 """
-function set_parameter!(ds, index, value)
-    if ds.p isa Union{AbstractArray, AbstractDict}
-        setindex!(ds.p, value, index)
+set_parameter!(ds::DynamicalSystem, args...) = _set_parameter!(ds.p, args...)
+# Generalized system case
+set_parameter!(x, args...) = _set_parameter!(x.integ.p, args...)
+
+function _set_parameter!(p, index, value)
+    if p isa Union{AbstractArray, AbstractDict}
+        setindex!(p, value, index)
     else
-        setproperty!(ds.p, index, value)
+        setproperty!(p, index, value)
     end
 end
 
-set_parameter!(ds, values) = (ds.p .= values)
+_set_parameter!(p, values) = (p .= values)
+
 
 
 #####################################################################################


### PR DESCRIPTION
Welp, this was missed since the dawn of time. No clue how many things it may break. But it certainly has to be done as I now realize it led to silently incorrect behavior.