### PR TITLE
Error checking with successful_step function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.1.0
+New error checking functionality added via `successful_step`. Returns `true` if the last `step!` call to `ds` was successful, `false` otherwise.
+For continuous time systems this uses DifferentialEquations.jl error checking,for discrete time it checks if any variable is `Inf` or `NaN`. Defaults to `true` for other types.   
+
 # v3.0
 
 Complete rewrite of the package. The DynamicalSystems.jl v3 changelog summarizes the highlights. Here we will list all changes to _this specific package_.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,7 @@ dynamic_rule
 current_time
 initial_time
 isinplace(::DynamicalSystem)
+successful_step
 ```
 
 ```@docs

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -129,7 +129,7 @@ abstract type DiscreteTimeDynamicalSystem <: DynamicalSystem end
 errormsg(ds) = "Not yet implemented for dynamical system of type $(nameof(typeof(ds)))."
 
 export current_state, initial_state, current_parameters, initial_parameters, isinplace,
-    current_time, initial_time, isdeterministic, isdiscretetime, dynamic_rule,
+    current_time, initial_time, successful_step, isdeterministic, isdiscretetime, dynamic_rule,
     reinit!, set_state!, set_parameter!, set_parameters!, step!
 
 ###########################################################################################

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -251,7 +251,7 @@ for discrete time it checks if any variable is `Inf` or `NaN`.
 
 """
 successful_step(ds::DynamicalSystem) = true
-successful_step(ds::DiscreteTimeDynamicalSystem) = any(x -> isinf(x) || isnan(x), current_state(ds))
+successful_step(ds::DiscreteTimeDynamicalSystem) = all(x -> isfinite(x) , current_state(ds))
 
 
 # Generic implementation, most types re-define it as compile-time info

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -100,6 +100,7 @@ unless when developing new algorithm implementations that use dynamical systems.
 - [`current_time`](@ref)
 - [`initial_time`](@ref)
 - [`isinplace`](@ref)
+- [`succesful_step`](@ref)
 
 ### API - alter status
 
@@ -240,6 +241,18 @@ in place. If `true`, the state is typically `Array`, if `false`, the state is ty
 but a developer may care.
 """
 SciMLBase.isinplace(ds::DynamicalSystem) = errormsg(ds)
+
+"""
+    successful_step(ds::DynamicalSystem) -> true/false
+
+Return `true` if the last `step!` call to `ds` was successful, `false` otherwise.
+For continuous time systems this uses DifferentialEquations.jl error checking,
+for discrete time it checks if any variable is `Inf` or `NaN`.
+
+"""
+successful_step(ds::DynamicalSystem) = true
+successful_step(ds::DiscreteTimeDynamicalSystem) = any(x -> isinf(x) || isnan(x), current_state(ds))
+
 
 # Generic implementation, most types re-define it as compile-time info
 StateSpaceSets.dimension(ds::DynamicalSystem) = length(current_state(ds))

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -249,7 +249,7 @@ Return `true` if the last `step!` call to `ds` was successful, `false` otherwise
 For continuous time systems this uses DifferentialEquations.jl error checking,
 for discrete time it checks if any variable is `Inf` or `NaN`.
 """
-successful_step(ds::DynamicalSystem) = nothing
+successful_step(ds::DynamicalSystem) = errormsg(ds)
 
 successful_step(ds::DiscreteTimeDynamicalSystem) = all(x -> isfinite(x) , current_state(ds))
 

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -250,7 +250,8 @@ For continuous time systems this uses DifferentialEquations.jl error checking,
 for discrete time it checks if any variable is `Inf` or `NaN`.
 
 """
-successful_step(ds::DynamicalSystem) = true
+successful_step(ds::DynamicalSystem) = nothing
+
 successful_step(ds::DiscreteTimeDynamicalSystem) = all(x -> isfinite(x) , current_state(ds))
 
 

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -248,7 +248,6 @@ SciMLBase.isinplace(ds::DynamicalSystem) = errormsg(ds)
 Return `true` if the last `step!` call to `ds` was successful, `false` otherwise.
 For continuous time systems this uses DifferentialEquations.jl error checking,
 for discrete time it checks if any variable is `Inf` or `NaN`.
-
 """
 successful_step(ds::DynamicalSystem) = nothing
 

--- a/src/core_systems/continuous_time_ode.jl
+++ b/src/core_systems/continuous_time_ode.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEq: Tsit5
-using SciMLBase: ODEProblem, DEIntegrator, u_modified!, __init, check_error, successful_retcode
+using SciMLBase: ODEProblem, DEIntegrator, u_modified!, __init
 export CoupledODEs, ContinuousDynamicalSystem
 
 ###########################################################################################
@@ -143,6 +143,8 @@ initial_state(integ::DEIntegrator) = integ.sol.prob.u0
 current_state(integ::DEIntegrator) = integ.u
 current_time(integ::DEIntegrator) = integ.t
 initial_time(integ::DEIntegrator) = integ.sol.prob.tspan[1]
+
+using SciMLBase: successful_retcode, check_error
 successful_step(integ::DEIntegrator) = successful_retcode(check_error(integ))
 
 function set_state!(integ::DEIntegrator, u)

--- a/src/core_systems/continuous_time_ode.jl
+++ b/src/core_systems/continuous_time_ode.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEq: Tsit5
-using SciMLBase: ODEProblem, DEIntegrator, u_modified!, __init
+using SciMLBase: ODEProblem, DEIntegrator, u_modified!, __init, check_error, successful_retcode
 export CoupledODEs, ContinuousDynamicalSystem
 
 ###########################################################################################
@@ -119,7 +119,7 @@ end
 StateSpaceSets.dimension(::CoupledODEs{IIP, D}) where {IIP, D} = D
 
 for f in (:current_state, :initial_state, :current_parameters, :dynamic_rule,
-    :current_time, :initial_time, :set_state!, :(SciMLBase.isinplace))
+    :current_time, :initial_time, :successful_step, :set_state!, :(SciMLBase.isinplace))
     @eval $(f)(ds::ContinuousTimeDynamicalSystem, args...) = $(f)(ds.integ, args...)
 end
 
@@ -143,6 +143,7 @@ initial_state(integ::DEIntegrator) = integ.sol.prob.u0
 current_state(integ::DEIntegrator) = integ.u
 current_time(integ::DEIntegrator) = integ.t
 initial_time(integ::DEIntegrator) = integ.sol.prob.tspan[1]
+successful_step(integ::DEIntegrator) = successful_retcode(check_error(integ))
 
 function set_state!(integ::DEIntegrator, u)
     if integ.u isa Array{<:Real}

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -102,7 +102,7 @@ end
 # Analytically knwon rule: extensions
 ###########################################################################################
 for f in (:(SciMLBase.step!), :current_time, :initial_time, :isdiscretetime, :reinit!,
-        :current_parameters, :initial_parameters
+        :current_parameters, :initial_parameters,:successful_step
     )
     @eval $(f)(pdsa::ParallelDynamicalSystemAnalytic, args...; kw...) = $(f)(pdsa.ds, args...; kw...)
 end

--- a/src/derived_systems/projected_system.jl
+++ b/src/derived_systems/projected_system.jl
@@ -91,7 +91,7 @@ additional_details(pds::ProjectedDynamicalSystem) = [
 ###########################################################################################
 # Everything besides `dimension`, `current/initia_state` and `reinit!` is propagated!
 for f in (:(SciMLBase.isinplace), :current_time, :initial_time, :isdiscretetime,
-        :current_parameters, :initial_parameters, :isdeterministic, :dynamic_rule,
+        :current_parameters, :initial_parameters, :isdeterministic, :dynamic_rule,:successful_step
     )
     @eval $(f)(tands::ProjectedDynamicalSystem, args...; kw...) = $(f)(tands.ds, args...; kw...)
 end

--- a/src/derived_systems/stroboscopic_map.jl
+++ b/src/derived_systems/stroboscopic_map.jl
@@ -51,7 +51,7 @@ set_period!(smap::StroboscopicMap, T) = (smap.period = T)
 # Extend interface
 ###########################################################################################
 for f in (:current_state, :initial_state, :current_parameters, :initial_parameters,
-	:dynamic_rule, :set_state!, :(SciMLBase.isinplace), :(StateSpaceSets.dimension))
+	:dynamic_rule, :set_state!,:successful_step, :(SciMLBase.isinplace), :(StateSpaceSets.dimension))
     @eval $(f)(smap::StroboscopicMap, args...) = $(f)(smap.ds, args...)
 end
 current_time(smap::StroboscopicMap) = smap.t

--- a/src/derived_systems/tangent_space.jl
+++ b/src/derived_systems/tangent_space.jl
@@ -203,7 +203,7 @@ dynamic_rule(tands::TangentDynamicalSystem) = tands.original_f
 (tands::TangentDynamicalSystem)(t::Real) = tands.ds(t)[:, 1]
 
 for f in (:current_time, :initial_time, :isdiscretetime,
-        :current_parameters, :initial_parameters, :isinplace,
+        :current_parameters, :initial_parameters, :isinplace,:successful_step,
     )
     @eval $(f)(tands::TangentDynamicalSystem, args...; kw...) = $(f)(tands.ds, args...; kw...)
 end
@@ -211,6 +211,7 @@ current_state(t::TangentDynamicalSystem{true}) = view(current_state(t.ds), :, 1)
 current_state(t::TangentDynamicalSystem{false}) = current_state(t.ds)[:, 1]
 initial_state(t::TangentDynamicalSystem{true}) = view(initial_state(t.ds), :, 1)
 initial_state(t::TangentDynamicalSystem{false}) = initial_state(t.ds)[:, 1]
+
 
 """
     current_deviations(tands::TangentDynamicalSystem)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ testfile(file, testname=defaultname(file)) = @testset "$testname" begin; include
     testfile("tangent.jl")
     testfile("poincare.jl")
     testfile("projected.jl")
+    testfile("successful_step.jl")
 end

--- a/test/successful_step.jl
+++ b/test/successful_step.jl
@@ -1,0 +1,44 @@
+using Test
+using DynamicalSystemsBase
+using OrdinaryDiffEq: Vern9
+
+@testset "successful_step tests -> unstable systems" begin
+
+	############## define unstable dynamical rules ##################
+	#exp_rule_discrete(x, p, n) = SVector(p[1]*Base.exp(x[1]), p[2]*Base.exp(-x[2]))
+	exp_rule(x, p, t) = SVector(p[1]*Base.exp(x[1]), p[2]*Base.exp(-x[2]))
+	u0 = ones(2)
+	p0 = [1.0, 2.0]
+	
+	#discrete
+	dim = DeterministicIteratedMap(exp_rule, u0, p0) 
+	
+	#continuous
+	diffeq = (alg = Vern9(), abstol = 1e-9, reltol = 1e-9)
+	ode = CoupledODEs(exp_rule, u0, p0; diffeq)
+	
+	#projected
+	projection = [1]
+	complete_state = [0.0]
+	pr = ProjectedDynamicalSystem(ode, projection, complete_state)
+	
+	#parallel
+	states = [u0,u0]
+	pds = ParallelDynamicalSystem(ode,states)
+
+	#tangent
+	tds = TangentDynamicalSystem(ode)
+	
+	#stroboscopic
+	sm = StroboscopicMap(ode,0.5)
+	
+	#stepping and testing
+	for sys in [dim,ode,pr,pds,tds,sm]
+		for _ in 1:100
+			step!(sys)
+		end
+		@show sys
+		@test successful_step(sys) == false
+	end
+end
+

--- a/test/successful_step.jl
+++ b/test/successful_step.jl
@@ -20,17 +20,17 @@ using OrdinaryDiffEq: Vern9
 	#projected
 	projection = [1]
 	complete_state = [0.0]
-	pr = ProjectedDynamicalSystem(ode, projection, complete_state)
+	pr = ProjectedDynamicalSystem(deepcopy(ode), projection, complete_state)
 	
 	#parallel
 	states = [u0,u0]
-	pds = ParallelDynamicalSystem(ode,states)
+	pds = ParallelDynamicalSystem(deepcopy(ode),states)
 
 	#tangent
-	tds = TangentDynamicalSystem(ode)
+	tds = TangentDynamicalSystem(deepcopy(ode))
 	
 	#stroboscopic
-	sm = StroboscopicMap(ode,0.5)
+	sm = StroboscopicMap(deepcopy(ode),0.5)
 	
 	#stepping and testing
 	for sys in [dim,ode,pr,pds,tds,sm]

--- a/test/successful_step.jl
+++ b/test/successful_step.jl
@@ -37,7 +37,6 @@ using OrdinaryDiffEq: Vern9
 		for _ in 1:100
 			step!(sys)
 		end
-		@show sys
 		@test successful_step(sys) == false
 	end
 end


### PR DESCRIPTION
Hi! I've added `successful_step` as part of the DynamicalSystemsBase API. For now it seemed like a good first step to implement it for `ContinuousTimeDynamicalSystem` type (it uses already available `SciMLBase` functions), but it can be extended to others as well, depending how general we want it to be. 
An older version of this PR was discussed at https://github.com/JuliaDynamics/DynamicalSystemsBase.jl/pull/147 and had the purpose to have an error checking tool that can be used to stop trajectory, lyapunov etc. calculations in case stepping is unsuccessful.