### PR TITLE
Small bug in projected system initial check

### DIFF
--- a/src/derived_systems/projected_system.jl
+++ b/src/derived_systems/projected_system.jl
@@ -73,7 +73,8 @@ function ProjectedDynamicalSystem(ds::DynamicalSystem, projection, complete_stat
         remidxs = setdiff(1:dimension(ds), projection)
         !isempty(remidxs) || error("Error with the indices of the projection")
     else
-        length(complete_state(u0)) == dimension(ds) || 
+        @show complete_state(y)
+        length(complete_state(y)) == dimension(ds) || 
                         error("The returned vector of complete_state must equal dimension(ds)")
         remidxs = nothing
     end

--- a/test/projected.jl
+++ b/test/projected.jl
@@ -14,6 +14,7 @@ p0_cont = [0.1, -0.4, -0.2]
 proj_comp1 = (1:2, [1.0])
 proj_comp2 = (1:2, (y) -> [y[1], y[2], y[2] + 1])
 proj_comp3 = (u -> u/norm(u), y -> 10y)
+proj_comp4 = (1:2, y -> [y..., 0])
 
 function projected_tests(ds, pds, P)
     @testset "projected dedicated" begin
@@ -43,13 +44,13 @@ function projected_tests(ds, pds, P)
     end
 end
 
-@testset "IDT=$(IDT), IIP=$(IIP) proj=$(P)" for IDT in (true, false), IIP in (false, true), P in (1, 2, 3)
+@testset "IDT=$(IDT), IIP=$(IIP) proj=$(P)" for IDT in (true, false), IIP in (false, true), P in (1, 2, 3, 4)
     SystemType = IDT ? DeterministicIteratedMap : CoupledODEs
     rule = !IIP ? trivial_rule : trivial_rule_iip
     p0 = IDT ? p0_disc : p0_cont
     ds = SystemType(rule, u0, p0)
 
-    projection, complete = (proj_comp1, proj_comp2, proj_comp3)[P]
+    projection, complete = (proj_comp1, proj_comp2, proj_comp3, proj_comp4)[P]
     pds = ProjectedDynamicalSystem(ds, projection, complete)
     u0init = recursivecopy(current_state(pds))
 


### PR DESCRIPTION
The API specifies: `complete_state` produces the state for the original system **from** the projected state.

But in the function initial sanity check, the `complete_state` function was initialized with the full state `u0` instead of the projected state `y`. I fixed this and added a test for this case. 