### PR TITLE
Fix small warning bug in data poincaresos 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.4.0"
+version = "3.4.1"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/derived_systems/poincare/hyperplane.jl
+++ b/src/derived_systems/poincare/hyperplane.jl
@@ -90,7 +90,7 @@ function poincaresos(A::AbstractStateSpaceSet, plane;
     i = typeof(save_idxs) <: Int ? save_idxs : SVector{length(save_idxs), Int}(save_idxs...)
     planecrossing = PlaneCrossing(plane, direction > 0)
     data = poincaresos(A, planecrossing, i)
-    warning && length(data) == 0 && @warn PSOS_ERROR
+    warning && length(data) == 0 && @warn "Poincaré surface of section does not contain any points!"
     return StateSpaceSet(data)
 end
 function poincaresos(A::StateSpaceSet, planecrossing::PlaneCrossing, j)


### PR DESCRIPTION
Small bug fix: `PSOS_ERROR` got deleted somehow along the way, inside `poincaresos(A::AbstractStateSpaceSet...)`. Since it is used in one place, I didn't redefine it, just wrote a simple warning.

MWE:
```
ts = rand(100,3)
poincaresos(StateSpaceSet(ts), (1,0);save_idxs=[2,3])
```