### PR TITLE
modify the requisite on the function complete_state

### DIFF
--- a/src/derived_systems/projected_system.jl
+++ b/src/derived_systems/projected_system.jl
@@ -15,7 +15,8 @@ Otherwise, `projection` can be an arbitrary function that given the state of the
 original system `ds`, returns the state in the projected space. In this case the projected
 space can be equal, or even higher-dimensional, than the original.
 
-`complete_state` produces the state for the original system from the projected state.
+`complete_state` produces the state for the original system, it can be any form of input as long
+as the returned vector is a valid state in the original space. 
 `complete_state` can always be a function that given the projected state returns a state in
 the original space. However, if `projection isa AbstractVector{Int}`, then `complete_state`
 can also be a vector that contains the values of the _remaining_ variables of the system,
@@ -73,8 +74,11 @@ function ProjectedDynamicalSystem(ds::DynamicalSystem, projection, complete_stat
         remidxs = setdiff(1:dimension(ds), projection)
         !isempty(remidxs) || error("Error with the indices of the projection")
     else
-        length(complete_state(y)) == dimension(ds) ||
-                        error("The returned vector of complete_state must equal dimension(ds)")
+        if complete_state isa Function
+            @warn "Make sure that the function complete_state returns a valid vector of the same dimension than ds"
+        end
+        # length(complete_state(y)) == dimension(ds) ||
+                        # error("The returned vector of complete_state must equal dimension(ds)")
         remidxs = nothing
     end
     u = zeros(dimension(ds))

--- a/test/projected.jl
+++ b/test/projected.jl
@@ -15,6 +15,7 @@ proj_comp1 = (1:2, [1.0])
 proj_comp2 = (1:2, (y) -> [y[1], y[2], y[2] + 1])
 proj_comp3 = (u -> u/norm(u), y -> 10y)
 proj_comp4 = (1:2, y -> [y..., 0])
+proj_comp5 = (u -> u, y -> y[1]+y[2]+y[3])
 
 function projected_tests(ds, pds, P)
     @testset "projected dedicated" begin
@@ -44,13 +45,13 @@ function projected_tests(ds, pds, P)
     end
 end
 
-@testset "IDT=$(IDT), IIP=$(IIP) proj=$(P)" for IDT in (true, false), IIP in (false, true), P in (1, 2, 3, 4)
+@testset "IDT=$(IDT), IIP=$(IIP) proj=$(P)" for IDT in (true, false), IIP in (false, true), P in (1, 2, 3, 4, 5)
     SystemType = IDT ? DeterministicIteratedMap : CoupledODEs
     rule = !IIP ? trivial_rule : trivial_rule_iip
     p0 = IDT ? p0_disc : p0_cont
     ds = SystemType(rule, u0, p0)
 
-    projection, complete = (proj_comp1, proj_comp2, proj_comp3, proj_comp4)[P]
+    projection, complete = (proj_comp1, proj_comp2, proj_comp3, proj_comp4, proj_comp5)[P]
     pds = ProjectedDynamicalSystem(ds, projection, complete)
     u0init = recursivecopy(current_state(pds))
 


### PR DESCRIPTION
Following the discussion in issue #209 I propose to loosen the requisites on the function `complete_state` for the `ProjectedDynamicalSystem`. The only important aspect is that the function `complete_state` should return a valid  vector on the original state space. 

Unfortunately I don't think we can make this check in the code if we don't know the kind of input `y`. 

