### PR TITLE
`ParallelDynamicalSystem` for `StroboscopicMap` and other API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.13.1"
+version = "3.13.2"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -177,6 +177,14 @@ function set_state!(pdsa::PDSAM, u::AbstractArray, i::Int = 1)
     return pdsa
 end
 
+
+function set_state!(pdsa::PDSAM{<: StroboscopicMap}, u::AbstractArray, i::Int = 1) where D
+    current_state(pdsa, i) .= u
+    u_modified!(pdsa.ds.ds.integ, true)
+    return pdsa
+end
+
+
 # We make one more extension here: for continuous time, in place systems
 # the state is a matrix (each column a parallel state) for performance.
 # re-init will not work because there is no way to do the recursive copy. we do it ourselves

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -67,7 +67,7 @@ function ParallelDynamicalSystem(ds::CoreDynamicalSystem, states::Vector{<:Abstr
     return ParallelDynamicalSystemAnalytic{typeof(pds), M}(pds, dynamic_rule(ds), prob)
 end
 
-function ParallelDynamicalSystem(smap::StroboscopicMap,states::Vector{<:AbstractArray{<:Real}})
+function ParallelDynamicalSystem(smap::StroboscopicMap,states)
     f, st = parallel_rule(smap.ds, states)
     T = eltype(first(st))
     prob = ODEProblem{true}(f, st, (T(initial_time(smap)), T(Inf)), current_parameters(smap))
@@ -178,7 +178,7 @@ function set_state!(pdsa::PDSAM, u::AbstractArray, i::Int = 1)
 end
 
 
-function set_state!(pdsa::PDSAM{<: StroboscopicMap}, u::AbstractArray, i::Int = 1) where D
+function set_state!(pdsa::PDSAM{<: StroboscopicMap}, u::AbstractArray, i::Int = 1)
     current_state(pdsa, i) .= u
     u_modified!(pdsa.ds.ds.integ, true)
     return pdsa

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -223,7 +223,7 @@ current_states(pdtds::PDTDS) = [current_state(ds) for ds in pdtds.systems]
 initial_states(pdtds::PDTDS) = [initial_state(ds) for ds in pdtds.systems]
 
 # Set stuff
-set_parameter!(pdtds::PDTDS) = for ds in pdtds.systems; set_parameter!(ds, args...); end
+set_parameter!(pdtds::PDTDS,index,value) = for ds in pdtds.systems; set_parameter!(ds, index,value); end
 function set_state!(pdtds::PDTDS, u, i::Int = 1)
     # We need to set state in all systems, in case this does
     # some kind of resetting, e.g., the `u_modified!` stuff.

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,3 +1,4 @@
+using Revise #remove this
 using DynamicalSystemsBase, Test
 using LinearAlgebra: norm
 
@@ -98,7 +99,7 @@ for (ds, idt, iip) in zip(
 end
 
 @testset "parallel stroboscopic" begin
-# Generic Parallel
+
 @inbounds function duffing_rule(x, p, t)
     ω, f, d, β = p
     dx1 = x[2]
@@ -122,9 +123,41 @@ states = [u0, u0 .+ 0.01]
 pds_cont_oop = ParallelDynamicalSystem(duffing_oop, states)
 pds_cont_iip = ParallelDynamicalSystem(duffing_iip, deepcopy(states))
 
+#generic ds test 
 @testset "IIP=$iip" for (ds, iip) in zip((pds_cont_oop, pds_cont_iip,), (true, false))
     test_dynamical_system(ds, u0, p0; idt = true, iip = true, test_trajectory = false)
 end
+
+#tests for multistate stuff
+
+#alteration
+states = [ones(2) for i in 1:2]
+p = p0 .+ 0.1
+for i in 1:2
+    set_state!(pds_cont_oop,states[i],i)
+    set_state!(pds_cont_iip,states[i],i)
+end
+set_parameters!(pds_cont_oop,p)
+set_parameters!(pds_cont_iip,p)
+
+#obtaining info
+@test all(current_states(pds_cont_oop) .== states)
+@test all(current_states(pds_cont_iip) .== states)
+@test all(current_parameters(pds_cont_oop) .== p)
+@test all(current_parameters(pds_cont_iip) .== p)
+
+#time evolution
+step!(pds_cont_oop)
+@test all(current_states(pds_cont_oop)[1] .== current_states(pds_cont_oop)[2])
+step!(pds_cont_iip)
+@test all(current_states(pds_cont_iip)[1] .== current_states(pds_cont_iip)[2])
+
+#reinit!
+reinit!(pds_cont_oop)
+reinit!(pds_cont_iip)
+@test all(current_states(pds_cont_oop) .== initial_states(pds_cont_oop))
+@test all(current_states(pds_cont_iip) .== initial_states(pds_cont_iip))
+
 end
 
 # TODO: Test that Lyapunovs of this match the original system

--- a/test/parallel.jl
+++ b/test/parallel.jl
@@ -1,4 +1,3 @@
-using Revise #remove this
 using DynamicalSystemsBase, Test
 using LinearAlgebra: norm
 
@@ -162,3 +161,5 @@ end
 
 # TODO: Test that Lyapunovs of this match the original system
 # But test this in ChaosTools.jl
+
+#benchmarks, comparison with old version


### PR DESCRIPTION
As mentioned [here](https://github.com/JuliaDynamics/ChaosTools.jl/issues/337), there is specialized parallel integrator for `CoupledODEs` and a generic fallback that copies systems for anything else. But `Stroboscopicmap` is actually just an ODE under the hood.

This PR attempts to implement the same specialized parallel `ODEProblem` that is built when `ParallelDynamicalSystem(ds::CoreDynamicalSystem, states::Vector{<:AbstractArray{<:Real}})`  is called on a `CoupledODEs` system, but for the `StroboscopicMap` . This is done by a new method that creates a parallel rule from the ODEs behind the `StroboscopicMap` (`parallel_rule(smap.ds, states)`).

Example:
```julia
function duffing_drift(u0 = [0.1, 0.25]; ω = 1.0, β = 0.2, ε0 = 0.4, α=0.00045)
  return CoupledODEs(duffing_drift_rule, u0, [ω, β, ε0, α])
end

@inbounds function duffing_drift_rule(x, p, t)
   ω, β, ε0, α = p
   dx1 = x[2]
   dx2 = (ε0+α*t)*cos(ω*t) + x[1] - x[1]^3 - 2β * x[2]
   return SVector(dx1, dx2)
end 

duffing = duffing_drift()
duffing_map = StroboscopicMap(duffing,2π)

pds = ParallelDynamicalSystem(duffing_map,[[0.1,0.2],[0.3,0.4]])
```
which creates a `ParallelDynamicalSystemAnalytic`.

The problem is that 
```julia
pds = ParallelDynamicalSystem(duffing_map,StateSpaceSet(rand(3,2)))
```
still dispatches to the `ParallelDiscreteTimeDynamicalSystem` generic fallback. Which is weird, right?
I think it shouldn't depend on the type of the states, I need to think about this more.

Also, this PR contains a small fix for the `set_parameter!` method that dispatches to the generic fallback system (see #223 ).