### PR TITLE
fix: set max time span to 1e16 for CoupledSDEs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.12.1"
+version = "3.12.2"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/ext/src/CoupledSDEs.jl
+++ b/ext/src/CoupledSDEs.jl
@@ -51,7 +51,7 @@ function DynamicalSystemsBase.CoupledSDEs(
         f,
         g,
         s,
-        (T(t0), T(1e16)),
+        (T(t0), T(1e11)),
         p;
         noise_rate_prototype=noise_prototype,
         noise=noise_process,

--- a/ext/src/CoupledSDEs.jl
+++ b/ext/src/CoupledSDEs.jl
@@ -51,7 +51,7 @@ function DynamicalSystemsBase.CoupledSDEs(
         f,
         g,
         s,
-        (T(t0), T(Inf)),
+        (T(t0), T(1e16)),
         p;
         noise_rate_prototype=noise_prototype,
         noise=noise_process,

--- a/test/stochastic.jl
+++ b/test/stochastic.jl
@@ -1,6 +1,6 @@
 using DynamicalSystemsBase, Test
 using OrdinaryDiffEq: Tsit5
-using StochasticDiffEq: SDEProblem, SRA, SOSRA, LambaEM, CorrelatedWienerProcess
+using StochasticDiffEq: SDEProblem, SRA, SOSRA, LambaEM, CorrelatedWienerProcess, EM
 
 StochasticSystemsBase = Base.get_extension(DynamicalSystemsBase, :StochasticSystemsBase)
 diffusion_matrix = StochasticSystemsBase.diffusion_matrix
@@ -148,9 +148,11 @@ end
     @testset "approximate cov" begin
         Γ = [1.0 0.3; 0.3 1]
         f(u, p, t) = [0.0, 0.0]
+        diffeq_cov = (alg = EM(), abstol = 1e-2, reltol = 1e-2, dt=0.1)
+
         ds = CoupledSDEs(f, zeros(2), (); covariance = Γ, diffeq=diffeq_cov)
-        tr, _ = trajectory(ds, 1_000, Δt=0.1)
-        approx = cov(diff(reduce(hcat, tr.data), dims=2), dims=2)
+        tr, _ = trajectory(ds, 10_000, Δt=0.1)
+        approx = cov(diff(reduce(hcat, tr.data), dims=2)./sqrt(0.1), dims=2)
         @test approx ≈ Γ atol=1e-1
     end
 end

--- a/test/stochastic.jl
+++ b/test/stochastic.jl
@@ -149,9 +149,8 @@ end
         Γ = [1.0 0.3; 0.3 1]
         f(u, p, t) = [0.0, 0.0]
         ds = CoupledSDEs(f, zeros(2), (); covariance = Γ, diffeq=diffeq_cov)
-        tr, _ = trajectory(ds, 1_000)
+        tr, _ = trajectory(ds, 1_000, Δt=0.1)
         approx = cov(diff(reduce(hcat, tr.data), dims=2), dims=2)
-        @test approx ≈ Γ atol=1e-1 broken = true
-        # I think I understand something wromg here
+        @test approx ≈ Γ atol=1e-1
     end
 end


### PR DESCRIPTION
For stochastic integrators, we can't have the timespan to be infinite because otherwise `eps(Inf)` is called in `StochasticDiffEq`. Instead, I have set it too 1e16. `eps(Inf)` is only called for non-adaptive timestep solvers.

https://github.com/SciML/StochasticDiffEq.jl/blob/9a28c57060980924d1fe040686f49c579ed9a1e2/src/integrators/integrator_utils.jl#L164-L167

At the moment, running trajectory with a non-adaptive time step solver fails:
```julia
using StatsBase: cov
diffeq_cov = (alg=EM(), abstol=1e-2, reltol=1e-2, dt=0.1)

Γ = [1.0 0.3; 0.3 1]
f(u, p, t) = [0.0, 0.0]
ds = CoupledSDEs(f, zeros(2), (); covariance=Γ, diffeq=diffeq_cov)
tr, _ = trajectory(ds, 1_000, Δt=0.1)
```
```julia
[1] (::Base.Math.var"#throw1#10")(x::Float64)
    @ Base.Math .\math.jl:1006
  [2] exponent
    @ .\math.jl:1009 [inlined]
  [3] eps
    @ .\float.jl:966 [inlined]
  [4] loopfooter!
    @ C:\Users\User\.julia\packages\StochasticDiffEq\NuzKA\src\integrators\integrator_utils.jl:167 [inlined]
  [5] step!
    @ C:\Users\User\.julia\packages\StochasticDiffEq\NuzKA\src\iterator_interface.jl:12 [inlined]
  [6] step!(::CoupledSDEs{false, 2, StochasticDiffEq.SDEIntegrator{…}, Tuple{}})
    @ StochasticSystemsBase C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\ext\src\CoupledSDEs.jl:171
  [7] trajectory_continuous(ds::CoupledSDEs{…}, T::Int64; Dt::Float64, Δt::Float64, Ttr::Float64, accessor::Nothing, kw::@Kwargs{})
    @ DynamicalSystemsBase C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\src\core\trajectory.jl:85
  [8] trajectory_continuous
    @ C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\src\core\trajectory.jl:75 [inlined]
  [9] #trajectory#5
    @ C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\src\core\trajectory.jl:44 [inlined]
 [10] trajectory
    @ C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\src\core\trajectory.jl:36 [inlined]
 [11] trajectory(ds::CoupledSDEs{false, 2, StochasticDiffEq.SDEIntegrator{…}, Tuple{}}, T::Int64)
    @ DynamicalSystemsBase C:\Users\User\.julia\packages\DynamicalSystemsBase\PJv07\src\core\trajectory.jl:36
 [12] top-level scope
    @ c:\Users\User\Documents\Github\CriticalTransitions.jl\test\using CriticalTransitions.jl:9
```


