### PR TITLE
fix: warning import since v1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.15.3"
+version = "3.15.4"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/ext/src/CoupledSDEs.jl
+++ b/ext/src/CoupledSDEs.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra: LinearAlgebra
+import DynamicalSystemsBase: CoupledSDEs
 
 ###########################################################################################
 # DiffEq options


### PR DESCRIPTION
Fixes:

```julia
┌ DynamicalSystemsBase → StochasticSystemsBase
│  WARNING: Constructor for type "CoupledSDEs" was extended in `StochasticSystemsBase` without explicit qualification or import.
│    NOTE: Assumed "CoupledSDEs" refers to `DynamicalSystemsBase.CoupledSDEs`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function CoupledSDEs end`.
│    Hint: To silence the warning, qualify `CoupledSDEs` as `DynamicalSystemsBase.CoupledSDEs` in the method signature or explicitly `import DynamicalSystemsBase: CoupledSDEs`.
└  
```