### PR TITLE
build(deps): move the SciMLBasev3, SDEv7, ODEv8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.15.7"
+version = "3.16.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -24,12 +24,12 @@ StochasticSystemsBase = "StochasticDiffEq"
 
 [compat]
 ForwardDiff = "0.10, 1"
-OrdinaryDiffEqTsit5 = "1.1"
+OrdinaryDiffEqTsit5 = "2"
 Reexport = "1"
-Roots = "1, 2"
-SciMLBase = "1.19.5, 2"
+Roots = "2, 3"
+SciMLBase = "3"
 StateSpaceSets = "2.5"
 Statistics = "1"
-StochasticDiffEq = "6.66.0"
+StochasticDiffEq = "7"
 SymbolicIndexingInterface = "0.3.4"
-julia = "1.9"
+julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![CI](https://github.com/JuliaDynamics/DynamicalSystemsBase.jl/workflows/CI/badge.svg)](https://github.com/JuliaDynamics/DynamicalSystemsBase.jl/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/JuliaDynamics/DynamicalSystemsBase.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaDynamics/DynamicalSystemsBase.jl)
 [![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Ftotal_downloads%2FDynamicalSystemsBase&query=total_requests&label=Downloads)](https://juliapkgstats.com/pkg/DynamicalSystemsBase)
-[![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Fmonthly_downloads%2FDynamicalSystemsBase&query=total_requests&suffix=%2Fmonth&label=Downloads)](https://juliapkgstats.com/pkg/DynamicalSystemsBase)
 
 A Julia package that defines the `DynamicalSystem` interface and many concrete implementations used in the DynamicalSystems.jl ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![](https://img.shields.io/badge/DOI-10.1007%2F978--3--030--91032--7-purple)](https://link.springer.com/book/10.1007/978-3-030-91032-7)
 [![CI](https://github.com/JuliaDynamics/DynamicalSystemsBase.jl/workflows/CI/badge.svg)](https://github.com/JuliaDynamics/DynamicalSystemsBase.jl/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/JuliaDynamics/DynamicalSystemsBase.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaDynamics/DynamicalSystemsBase.jl)
-[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/DynamicalSystemsBase)](https://pkgs.genieframework.com?packages=DynamicalSystemsBase)
+[![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Ftotal_downloads%2FDynamicalSystemsBase&query=total_requests&label=Downloads)](https://juliapkgstats.com/pkg/DynamicalSystemsBase)
+[![Downloads](https://img.shields.io/badge/dynamic/json?url=http%3A%2F%2Fjuliapkgstats.com%2Fapi%2Fv1%2Fmonthly_downloads%2FDynamicalSystemsBase&query=total_requests&suffix=%2Fmonth&label=Downloads)](https://juliapkgstats.com/pkg/DynamicalSystemsBase)
 
 A Julia package that defines the `DynamicalSystem` interface and many concrete implementations used in the DynamicalSystems.jl ecosystem.
 

--- a/ext/StochasticSystemsBase.jl
+++ b/ext/StochasticSystemsBase.jl
@@ -3,7 +3,7 @@ module StochasticSystemsBase
 using DynamicalSystemsBase: DynamicalSystemsBase, SciMLBase, correct_state, CoupledODEs,
     CoupledSDEs, StateSpaceSets, isinplace, _delete, set_parameter!,
     set_parameters!, set_state!, dynamic_rule, isdeterministic, current_state,
-    DynamicalSystemsBase, _set_parameter!, u_modified!,
+    DynamicalSystemsBase, _set_parameter!, derivative_discontinuity!,
     additional_details, referrenced_sciml_prob, DEFAULT_DIFFEQ,
     SVector, SMatrix, current_parameters, initial_state, initial_time
 using SciMLBase: SDEProblem, AbstractSDEIntegrator, __init, SDEFunction, step!

--- a/ext/src/CoupledSDEs.jl
+++ b/ext/src/CoupledSDEs.jl
@@ -208,10 +208,10 @@ function DynamicalSystemsBase.successful_step(integ::AbstractSDEIntegrator)
     return rcode == SciMLBase.ReturnCode.Default || rcode == SciMLBase.ReturnCode.Success
 end
 
-# This is here to ensure that `u_modified!` is called
+# This is here to ensure that `derivative_discontinuity!` is called
 function DynamicalSystemsBase.set_parameter!(ds::CoupledSDEs, args...)
     _set_parameter!(ds, args...)
-    u_modified!(ds.integ, true)
+    derivative_discontinuity!(ds.integ, true)
     return nothing
 end
 

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -144,11 +144,11 @@ Return the ModelingToolkit.jl structurally-simplified model referrenced by `ds`.
 Return `nothing` if there is no referrenced model.
 """
 referrenced_sciml_model(ds::DynamicalSystem) = referrenced_sciml_model(referrenced_sciml_prob(ds))
-referrenced_sciml_model(prob::SciMLBase.DEProblem) = prob.f.sys
+referrenced_sciml_model(prob::SciMLBase.AbstractDEProblem) = prob.f.sys
 referrenced_sciml_model(::Nothing) = nothing
 
 # return true if there is an actual referrenced system
-has_referrenced_model(prob::SciMLBase.DEProblem) = has_referrenced_model(referrenced_sciml_model(prob))
+has_referrenced_model(prob::SciMLBase.AbstractDEProblem) = has_referrenced_model(referrenced_sciml_model(prob))
 has_referrenced_model(prob::DynamicalSystem) = has_referrenced_model(referrenced_sciml_model(prob))
 has_referrenced_model(::Nothing) = false
 has_referrenced_model(::SymbolicIndexingInterface.SymbolCache{Nothing, Nothing, Nothing}) = false

--- a/src/core_systems/continuous_time_ode.jl
+++ b/src/core_systems/continuous_time_ode.jl
@@ -1,5 +1,5 @@
 using OrdinaryDiffEqTsit5: Tsit5
-using SciMLBase: ODEProblem, DEIntegrator, u_modified!, __init
+using SciMLBase: ODEProblem, DEIntegrator, derivative_discontinuity!, __init
 export CoupledODEs, ContinuousDynamicalSystem
 
 ###########################################################################################
@@ -183,14 +183,14 @@ function set_state!(integ::DEIntegrator, u)
     else
         integ.u = recursivecopy(u)
     end
-    u_modified!(integ, true)
+    derivative_discontinuity!(integ, true)
     return
 end
 
-# This is here to ensure that `u_modified!` is called
+# This is here to ensure that `derivative_discontinuity!` is called
 function set_parameter!(ds::CoupledODEs, args...)
     _set_parameter!(ds, args...)
-    u_modified!(ds.integ, true)
+    derivative_discontinuity!(ds.integ, true)
     return
 end
 

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -182,14 +182,14 @@ initial_states(pdsa::PDSAM) = eachcol(initial_state(pdsa.ds))
 (pdsa::PDSAM)(t::Real, i::Int = 1) = view(pdsa.ds(t), :, i)
 function set_state!(pdsa::PDSAM, u::AbstractArray, i::Int = 1)
     current_state(pdsa, i) .= u
-    u_modified!(pdsa.ds.integ, true)
+    derivative_discontinuity!(pdsa.ds.integ, true)
     return pdsa
 end
 
 
 function set_state!(pdsa::PDSAM{<:StroboscopicMap}, u::AbstractArray, i::Int = 1)
     current_state(pdsa, i) .= u
-    u_modified!(pdsa.ds.ds.integ, true)
+    derivative_discontinuity!(pdsa.ds.ds.integ, true)
     return pdsa
 end
 
@@ -248,7 +248,7 @@ set_parameter!(pdtds::PDTDS, index, value) = for ds in pdtds.systems
 end
 function set_state!(pdtds::PDTDS, u, i::Int = 1)
     # We need to set state in all systems, in case this does
-    # some kind of resetting, e.g., the `u_modified!` stuff.
+    # some kind of resetting, e.g., the `derivative_discontinuity!` stuff.
     for (k, ds) in enumerate(pdtds.systems)
         if k == i
             set_state!(ds, u)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,4 +10,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-ModelingToolkit = "10"
+ModelingToolkit = "10, 11"

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -1,6 +1,7 @@
 using DynamicalSystemsBase, Test
 
 using OrdinaryDiffEqTsit5: ODEProblem, Tsit5
+using OrdinaryDiffEqTsit5.OrdinaryDiffEqCore: None
 using OrdinaryDiffEqVerner: Vern9
 
 include("test_system_function.jl")
@@ -39,7 +40,9 @@ end
     @test lorenz_oop.integ.alg isa Tsit5
 
     prob = lorenz_oop.integ.sol.prob
-    ds = CoupledODEs(prob, (alg = Vern9(), abstol = 0.0, reltol = 1.0e-6, verbose = false))
+    ds = CoupledODEs(
+        prob, (alg = Vern9(), abstol = 0.0, reltol = 1.0e-6, verbose = None())
+    )
     @test ds.integ.alg isa Vern9
     # SciML moved from Bool verbose to a `DEVerbosity` struct of per-toggle verbosities.
     @test nameof(typeof(ds.integ.opts.verbose.linear_verbosity)) == :None

--- a/test/jacobian.jl
+++ b/test/jacobian.jl
@@ -43,7 +43,7 @@ end
     @named sys = System(eqs, t)
     sys = mtkcompile(sys)
 
-    prob = ODEProblem(sys, [1.0, 1.0], (0.0, 1.0); jac = true)
+    prob = ODEProblem(sys, [u[1] => 1.0, u[2] => 1.0], (0.0, 1.0); jac = true)
     ds = CoupledODEs(prob)
 
     jac = jacobian(ds)
@@ -60,7 +60,7 @@ end
         ]
         @mtkcompile sys = System(eqs, t)
 
-        prob = SDEProblem(sys, [1.0, 1.0], (0.0, 1.0), jac = true)
+        prob = SDEProblem(sys, [u[1] => 1.0, u[2] => 1.0], (0.0, 1.0), jac = true)
         sde = CoupledSDEs(prob)
 
         jac = jacobian(sde)

--- a/test/mtk_integration.jl
+++ b/test/mtk_integration.jl
@@ -141,27 +141,15 @@ end
 
 @independent_variables t
 D = Differential(t)
-@mtkmodel Roessler begin
-    @parameters begin
-        a = 0.2
-        b = 0.2
-        c = 5.7
-    end
-    @variables begin
-        x(t) = 1.0
-        y(t) = 0.0
-        z(t) = 0.0
-        nlt(t) # nonlinear term
-    end
-    @equations begin
-        D(x) ~ -y - z
-        D(y) ~ x + a * y
-        D(z) ~ b + nlt
-        nlt ~ z * (x - c)
-    end
-end
-
-@mtkcompile roessler_model = Roessler()
+@parameters a = 0.2 b = 0.2 c = 5.7
+@variables x(t) = 1.0 y(t) = 0.0 z(t) = 0.0 nlt(t)
+eqs = [
+    D(x) ~ -y - z,
+    D(y) ~ x + a * y,
+    D(z) ~ b + nlt,
+    nlt ~ z * (x - c),
+]
+@mtkcompile roessler_model = System(eqs, t)
 
 @testset "type: $(iip)" for iip in (true, false)
     if iip

--- a/test/stochastic.jl
+++ b/test/stochastic.jl
@@ -1,5 +1,6 @@
 using DynamicalSystemsBase, Test
 using OrdinaryDiffEqTsit5: Tsit5
+using OrdinaryDiffEqTsit5.OrdinaryDiffEqCore: None
 using StochasticDiffEq: SDEProblem, SRA, SOSRA, LambaEM, CorrelatedWienerProcess, EM
 
 StochasticSystemsBase = Base.get_extension(DynamicalSystemsBase, :StochasticSystemsBase)
@@ -70,7 +71,7 @@ end
 
     lorenz_SRA = CoupledSDEs(
         lorenz_rule, u0, p0;
-        diffeq = (alg = SRA(), abstol = 1.0e-3, reltol = 1.0e-3, verbose = false)
+        diffeq = (alg = SRA(), abstol = 1.0e-3, reltol = 1.0e-3, verbose = None())
     )
     @test lorenz_SRA.integ.alg isa SRA
     # SciML moved from Bool verbose to a `DEVerbosity` struct of per-toggle verbosities.
@@ -79,7 +80,9 @@ end
     # also test SDEproblem creation
     prob = lorenz_SRA.integ.sol.prob
 
-    ds = CoupledSDEs(prob, (alg = SRA(), abstol = 0.0, reltol = 1.0e-3, verbose = false))
+    ds = CoupledSDEs(
+        prob, (alg = SRA(), abstol = 0.0, reltol = 1.0e-3, verbose = None())
+    )
 
     @test ds.integ.alg isa SRA
     @test nameof(typeof(ds.integ.opts.verbose.linear_verbosity)) == :None


### PR DESCRIPTION
## Summary

Brings DynamicalSystemsBase onto the SciMLBase v3 / OrdinaryDiffEq v7 wave: SciMLBase 3, OrdinaryDiffEqTsit5 2, StochasticDiffEq 7, Roots 3, ModelingToolkit 11 (tests), Julia 1.10.

## Source changes

- `u_modified!` -> `derivative_discontinuity!` (SciMLBase v3 rename) in `src/core_systems/continuous_time_ode.jl`, `src/derived_systems/parallel_systems.jl`, `ext/StochasticSystemsBase.jl`, `ext/src/CoupledSDEs.jl`
- `SciMLBase.DEProblem` -> `SciMLBase.AbstractDEProblem` in `src/core/dynamicalsystem_interface.jl` (v3 drops the `DEProblem` alias; `AbstractDEProblem` works on both v2 and v3)

## Compat

- `OrdinaryDiffEqTsit5 = "2"`
- `SciMLBase = "3"`
- `Roots = "2, 3"`
- `StochasticDiffEq = "7"`
- `julia = "1.10"` (required by SciMLBase v3)
- `test/Project.toml`: `ModelingToolkit = "10, 11"`

## Test migrations (downstream API changes, not ours)

- `verbose = false` -> `verbose = None()` in `test/continuous.jl`, `test/stochastic.jl`. OrdinaryDiffEq v7 rejects `verbose::Bool` at the API boundary.
- `ODEProblem(sys, [1.0, 1.0], tspan)` / `SDEProblem(sys, [1.0, 1.0], tspan)` -> symbolic-map u0 in `test/jacobian.jl`. MTK 11 requires the operating point as a symbolic map.
- Roessler model in `test/mtk_integration.jl` rewritten with the functional `System` / `@mtkcompile` form (the `@mtkmodel` DSL lives in `SciCompDSL.jl` now, separate from MTK).

## Test results

`1536 passed, 0 failed, 0 errored`.

## Downstream impact

DynamicalSystemsBase forwards the `diffeq` named tuple through to OrdinaryDiffEq / StochasticDiffEq. Users passing v6-era kwargs through this surface will now hit `ArgumentError`s from the upstream packages:

- `verbose = true/false` -> use `verbose = None()` / `Standard()` / `DEVerbosity(...)`
- `autodiff = true/false` -> use `AutoForwardDiff()` / `AutoFiniteDiff()` etc. from ADTypes
- `alias_u0 = true` -> use `alias = ODEAliasSpecifier(alias_u0 = true)`
- PID controller kwargs (`gamma`, `beta1`, `qmin`, ...) -> use `controller = PIController(...)` / `PIDController(...)`

See the OrdinaryDiffEq v7 NEWS for the full list.
