### PR TITLE
Rename referrenced -> referenced, deprecate old spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.18
+
+- The public API functions `referrenced_sciml_prob`, `referrenced_sciml_model`, and the internal `has_referrenced_model` have been renamed to fix the misspelling: `referenced_sciml_prob`, `referenced_sciml_model`, `has_referenced_model`. The misspelled names are kept as deprecated aliases that forward to the new ones, so existing code keeps working but emits a deprecation warning. `referenced_sciml_prob` is now also exported and documented.
+
 # v3.17
 
 - `CoupledSDEs` (along with `diffusion_matrix` and related utilities) is now part of the core package instead of living behind the `StochasticSystemsBase` package extension. Users no longer need to load `StochasticDiffEq` to construct or use `CoupledSDEs`, and `Base.get_extension` is no longer required to access `diffusion_matrix`.
@@ -86,7 +90,7 @@ model and all symbolic variables. Accessing a `DynamicalSystem` using symbolic v
 is possible via the functions [`observe_state`](@ref), [`set_state!`](@ref),
 [`current_parameter`](@ref) and [`set_parameter!`](@ref).
 The referenced MTK model corresponding to the dynamical system can be obtained with
-`model = referrenced_sciml_model(ds::DynamicalSystem)`.
+`model = referenced_sciml_model(ds::DynamicalSystem)`.
 
 See also the online overarching tutorial for an example.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicalSystemsBase"
 uuid = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"
 repo = "https://github.com/JuliaDynamics/DynamicalSystemsBase.jl.git"
-version = "3.17.0"
+version = "3.18.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ current_time
 initial_time
 isinplace(::DynamicalSystem)
 successful_step
-referrenced_sciml_model
+referenced_sciml_model
 named_variables
 ```
 

--- a/src/core/dynamicalsystem_interface.jl
+++ b/src/core/dynamicalsystem_interface.jl
@@ -52,7 +52,7 @@ model and all symbolic variables. Accessing a `DynamicalSystem` using symbolic v
 is possible via the functions [`observe_state`](@ref), [`set_state!`](@ref),
 [`current_parameter`](@ref) and [`set_parameter!`](@ref).
 The referenced MTK model corresponding to the dynamical system can be obtained with
-`model = referrenced_sciml_model(ds::DynamicalSystem)`.
+`model = referenced_sciml_model(ds::DynamicalSystem)`.
 
 See also the DynamicalSystems.jl tutorial online for an example.
 
@@ -92,7 +92,7 @@ unless when developing new algorithm implementations that use dynamical systems.
 - [`initial_time`](@ref)
 - [`isinplace`](@ref)
 - [`successful_step`](@ref)
-- [`referrenced_sciml_model`](@ref)
+- [`referenced_sciml_model`](@ref)
 - [`named_variables`](@ref)
 
 ### API - alter status
@@ -127,32 +127,40 @@ errormsg(ds) = error("Not yet implemented for dynamical system of type $(nameof(
 
 export current_state, initial_state, current_parameters, current_parameter, initial_parameters, isinplace,
     current_time, initial_time, successful_step, isdeterministic, isdiscretetime, dynamic_rule,
-    reinit!, set_state!, set_parameter!, set_parameters!, step!, observe_state, referrenced_sciml_model, named_variables
+    reinit!, set_state!, set_parameter!, set_parameters!, step!, observe_state,
+    referenced_sciml_model, referenced_sciml_prob, named_variables
 
 ###########################################################################################
 # Symbolic support
 ###########################################################################################
-# Simply extend the `referrenced_sciml_prob` and you have symbolic indexing support!
+# Simply extend the `referenced_sciml_prob` and you have symbolic indexing support!
 import SymbolicIndexingInterface
-referrenced_sciml_prob(::DynamicalSystem) = nothing
+"""
+    referenced_sciml_prob(ds::DynamicalSystem)
+
+Return the SciML problem (e.g. `ODEProblem`, `SDEProblem`) that `ds` was built from,
+or `nothing` if `ds` does not reference one. The returned problem is used for symbolic
+indexing through SymbolicIndexingInterface.jl.
+"""
+referenced_sciml_prob(::DynamicalSystem) = nothing
 
 # The rest are all automated!
 """
-    referrenced_sciml_model(ds::DynamicalSystem)
+    referenced_sciml_model(ds::DynamicalSystem)
 
-Return the ModelingToolkit.jl structurally-simplified model referrenced by `ds`.
-Return `nothing` if there is no referrenced model.
+Return the ModelingToolkit.jl structurally-simplified model referenced by `ds`.
+Return `nothing` if there is no referenced model.
 """
-referrenced_sciml_model(ds::DynamicalSystem) = referrenced_sciml_model(referrenced_sciml_prob(ds))
-referrenced_sciml_model(prob::SciMLBase.AbstractDEProblem) = prob.f.sys
-referrenced_sciml_model(::Nothing) = nothing
+referenced_sciml_model(ds::DynamicalSystem) = referenced_sciml_model(referenced_sciml_prob(ds))
+referenced_sciml_model(prob::SciMLBase.AbstractDEProblem) = prob.f.sys
+referenced_sciml_model(::Nothing) = nothing
 
-# return true if there is an actual referrenced system
-has_referrenced_model(prob::SciMLBase.AbstractDEProblem) = has_referrenced_model(referrenced_sciml_model(prob))
-has_referrenced_model(prob::DynamicalSystem) = has_referrenced_model(referrenced_sciml_model(prob))
-has_referrenced_model(::Nothing) = false
-has_referrenced_model(::SymbolicIndexingInterface.SymbolCache{Nothing, Nothing, Nothing}) = false
-has_referrenced_model(sys) = true
+# return true if there is an actual referenced system
+has_referenced_model(prob::SciMLBase.AbstractDEProblem) = has_referenced_model(referenced_sciml_model(prob))
+has_referenced_model(prob::DynamicalSystem) = has_referenced_model(referenced_sciml_model(prob))
+has_referenced_model(::Nothing) = false
+has_referenced_model(::SymbolicIndexingInterface.SymbolCache{Nothing, Nothing, Nothing}) = false
+has_referenced_model(sys) = true
 
 """
     named_variables(ds::DynamicalSystem)
@@ -165,7 +173,7 @@ X = StateSpaceSet(X; names = named_variables(ds))
 in downstream functions to name a set coming from `ds` (if possible).
 """
 function named_variables(ds::DynamicalSystem)
-    mtk = referrenced_sciml_model(ds)
+    mtk = referenced_sciml_model(ds)
     isnothing(mtk) && return nothing
     return SymbolicIndexingInterface.getname.(SymbolicIndexingInterface.variable_symbols(mtk))
 end
@@ -198,7 +206,7 @@ Return the state `u` of `ds` _observed_ at "index" `i`. Possibilities are:
 - `i::Int` returns the `i`-th dynamic variable.
 - `i::Function` returns `f(current_state(ds))`.
 - `i::SymbolLike` returns the value of the corresponding symbolic variable.
-   This is valid only for dynamical systems referrencing a ModelingToolkit.jl model
+   This is valid only for dynamical systems referencing a ModelingToolkit.jl model
    which also has `i` as one of its listed variables (either uknowns or observed).
    Here `i` can be anything can be anything
    that could index the solution object `sol = ModelingToolkit.solve(...)`,
@@ -220,8 +228,8 @@ function observe_state(ds::DynamicalSystem, index, u::AbstractArray = current_st
         return index(u)
     elseif index isa Integer
         return u[index]
-    elseif has_referrenced_model(ds)
-        prob = referrenced_sciml_prob(ds)
+    elseif has_referenced_model(ds)
+        prob = referenced_sciml_prob(ds)
         ugetter = SymbolicIndexingInterface.observed(prob, index)
         p = current_parameters(ds)
         return ugetter(u, p, t)
@@ -229,7 +237,7 @@ function observe_state(ds::DynamicalSystem, index, u::AbstractArray = current_st
         throw(
             ArgumentError(
                 "Invalid index to observe state, or if symbolic index, the " *
-                    "dynamical system does not referrence a ModelingToolkit.jl system."
+                    "dynamical system does not reference a ModelingToolkit.jl system."
             )
         )
     end
@@ -264,8 +272,8 @@ to extract the parameter from, which must match layout with its default value.
 Use [`parameter_name`](@ref) for an accompanying name.
 """
 function current_parameter(ds::DynamicalSystem, index, p = current_parameters(ds))
-    prob = referrenced_sciml_prob(ds)
-    if !has_referrenced_model(prob)
+    prob = referenced_sciml_prob(ds)
+    if !has_referenced_model(prob)
         return _get_parameter(p, index)
     else # symbolic parameter
         if !SymbolicIndexingInterface.is_parameter(prob, index)
@@ -389,17 +397,17 @@ function set_state!(ds::DynamicalSystem, value::Real, i)
 end
 
 function set_state!(u::AbstractArray, value::Real, i, ds::DynamicalSystem)
-    prob = referrenced_sciml_prob(ds)
+    prob = referenced_sciml_prob(ds)
     if i isa Integer
         u[i] = value
-    elseif has_referrenced_model(prob)
+    elseif has_referenced_model(prob)
         usetter = SymbolicIndexingInterface.setu(prob, i)
         usetter(u, value)
     else
         throw(
             ArgumentError(
                 "Invalid index to set state, or if symbolic index, the " *
-                    "dynamical system does not referrence a ModelingToolkit.jl system."
+                    "dynamical system does not reference a ModelingToolkit.jl system."
             )
         )
     end
@@ -451,8 +459,8 @@ function set_parameter!(ds::DynamicalSystem, index, value, p = current_parameter
     return _set_parameter!(ds::DynamicalSystem, index, value, p)
 end
 function _set_parameter!(ds::DynamicalSystem, index, value, p = current_parameters(ds))
-    prob = referrenced_sciml_prob(ds)
-    if !has_referrenced_model(prob)
+    prob = referenced_sciml_prob(ds)
+    if !has_referenced_model(prob)
         if p isa Union{AbstractArray, AbstractDict}
             setindex!(p, value, index)
         else

--- a/src/core/trajectory.jl
+++ b/src/core/trajectory.jl
@@ -12,7 +12,7 @@ Optionally provide a starting state `u0` which is `current_state(ds)` by default
 If time evolution diverged or in general failed before `T`,
 the remaining of the trajectory is set to the last valid point.
 
-The dimensions of `X` are automatically named if `ds` referrences an MTK model
+The dimensions of `X` are automatically named if `ds` references an MTK model
 and if `save_idxs` remains at its default value.
 
 ## Keyword arguments

--- a/src/core_systems/continuous_time_ode.jl
+++ b/src/core_systems/continuous_time_ode.jl
@@ -86,7 +86,7 @@ function CoupledODEs(f, u0, p = SciMLBase.NullParameters(); t0 = 0, diffeq = DEF
     prob = ODEProblem{IIP}(f, s, (T(t0), T(Inf)), p)
     return CoupledODEs(prob, diffeq)
 end
-# This preserves the referrenced MTK system and the originally passed diffeq kwargs
+# This preserves the referenced MTK system and the originally passed diffeq kwargs
 CoupledODEs(ds::CoupledODEs, diffeq) = CoupledODEs(ODEProblem(ds), merge(ds.diffeq, diffeq))
 # Below `special_kwargs` is undocumented internal option for passing `internalnorm`
 function CoupledODEs(prob::ODEProblem, diffeq = DEFAULT_DIFFEQ; special_kwargs...)
@@ -194,4 +194,4 @@ function set_parameter!(ds::CoupledODEs, args...)
     return
 end
 
-referrenced_sciml_prob(ds::CoupledODEs) = ds.integ.sol.prob
+referenced_sciml_prob(ds::CoupledODEs) = ds.integ.sol.prob

--- a/src/core_systems/continuous_time_sde.jl
+++ b/src/core_systems/continuous_time_sde.jl
@@ -223,7 +223,7 @@ function CoupledSDEs(
         integ, deepcopy(prob.p), diffeq, noise_type
     )
 end
-# This preserves the referrenced MTK system and the originally passed diffeq kwargs
+# This preserves the referenced MTK system and the originally passed diffeq kwargs
 CoupledSDEs(ds::CoupledSDEs, diffeq) = CoupledSDEs(SDEProblem(ds), merge(ds.diffeq, diffeq))
 
 """
@@ -270,7 +270,7 @@ function CoupledSDEs(
         noise_process = nothing,
         seed = rand(UInt64)
     )
-    prob = referrenced_sciml_prob(ds)
+    prob = referenced_sciml_prob(ds)
     # we want the symbolic jacobian to be transfered over
     # dynamic_rule(ds) takes the deepest nested f wich does not have a jac field
     return CoupledSDEs(
@@ -288,7 +288,7 @@ deterministic part of `ds`.
 function CoupledODEs(
         sys::CoupledSDEs; diffeq = DEFAULT_DIFFEQ, t0 = 0.0
     )
-    prob = referrenced_sciml_prob(sys)
+    prob = referenced_sciml_prob(sys)
     # we want the symbolic jacobian to be transfered over
     # dynamic_rule(ds) takes the deepest nested f wich does not have a jac field
     return CoupledODEs(
@@ -331,7 +331,7 @@ function set_parameter!(ds::CoupledSDEs, args...)
     return nothing
 end
 
-referrenced_sciml_prob(ds::CoupledSDEs) = ds.integ.sol.prob
+referenced_sciml_prob(ds::CoupledSDEs) = ds.integ.sol.prob
 
 """
     diffusion_matrix(ds::CoupledSDEs)
@@ -479,7 +479,7 @@ function diffusion_function(g, IIP, noise_prototype)
 end
 
 function diffusion_function(ds::CoupledSDEs{IIP}) where {IIP}
-    prob = referrenced_sciml_prob(ds)
+    prob = referenced_sciml_prob(ds)
     return diffusion_function(prob.g, IIP, prob.noise_rate_prototype)
 end
 

--- a/src/core_systems/jacobian.jl
+++ b/src/core_systems/jacobian.jl
@@ -23,8 +23,8 @@ function jacobian(ds::CoreDynamicalSystem{IIP}) where {IIP}
     if ds isa ContinuousTimeDynamicalSystem
         # TODO: This is the correct API way to obtain the Jacobian,
         # however it relies on MTK dependency, so we can't do it.
-        # if has_referrenced_model(ds)
-        #     model = referrenced_sciml_model(ds)
+        # if has_referenced_model(ds)
+        #     model = referenced_sciml_model(ds)
         #     Joop, Jiip = generate_jacobian(model; expression = Val{false})
         #     if IIP
         #         jac = Jiip
@@ -32,7 +32,7 @@ function jacobian(ds::CoreDynamicalSystem{IIP}) where {IIP}
         #         jac = Joop
         #     end
         # end
-        prob = referrenced_sciml_prob(ds)
+        prob = referenced_sciml_prob(ds)
         if prob.f isa SciMLBase.AbstractDiffEqFunction && !isnothing(prob.f.jac)
             jac = prob.f.jac
         else

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,6 +1,11 @@
 @deprecate get_state current_state
 @deprecate get_deviations current_deviations
 
+# Misspelled names kept for backwards compatibility; remove in a future breaking release.
+@deprecate referrenced_sciml_prob referenced_sciml_prob
+@deprecate referrenced_sciml_model referenced_sciml_model
+@deprecate has_referrenced_model has_referenced_model false
+
 export integrator, tangent_integrator, parallel_integrator, poincaremap
 export projected_integrator
 

--- a/src/derived_systems/parallel_systems.jl
+++ b/src/derived_systems/parallel_systems.jl
@@ -63,7 +63,7 @@ function ParallelDynamicalSystem(ds::CoreDynamicalSystem, states::Vector{<:Abstr
         pds = CoupledODEs(prob, ds.diffeq; internalnorm = inorm)
     end
     M = ds isa CoupledODEs && isinplace(ds)
-    prob = referrenced_sciml_prob(ds)
+    prob = referenced_sciml_prob(ds)
     return ParallelDynamicalSystemAnalytic{typeof(pds), M}(pds, dynamic_rule(ds), prob)
 end
 
@@ -76,7 +76,7 @@ function ParallelDynamicalSystem(smap::StroboscopicMap, states)
     pds = StroboscopicMap(cont_pds, smap.period)
 
     M = smap.ds isa CoupledODEs && isinplace(smap.ds)
-    prob = referrenced_sciml_prob(smap.ds)
+    prob = referenced_sciml_prob(smap.ds)
     return ParallelDynamicalSystemAnalytic{typeof(pds), M}(pds, dynamic_rule(smap), prob)
 end
 
@@ -148,7 +148,7 @@ end
 (pdsa::ParallelDynamicalSystemAnalytic)(t::Real, i::Int = 1) = pdsa.ds(t)[i]
 dynamic_rule(pdsa::ParallelDynamicalSystemAnalytic) = pdsa.original_f
 
-referrenced_sciml_prob(pdsa::ParallelDynamicalSystemAnalytic) = pdsa.prob
+referenced_sciml_prob(pdsa::ParallelDynamicalSystemAnalytic) = pdsa.prob
 
 function observe_state(ds::ParallelDynamicalSystemAnalytic, index, i::Int = 1)
     u = current_state(ds, i)
@@ -221,7 +221,7 @@ end
 
 for f in (
         :current_time, :initial_time, :isdiscretetime,
-        :current_parameters, :initial_parameters, :dynamic_rule, :referrenced_sciml_model,
+        :current_parameters, :initial_parameters, :dynamic_rule, :referenced_sciml_model,
     )
     @eval $(f)(pdtds::PDTDS, args...; kw...) = $(f)(pdtds.systems[1], args...; kw...)
 end

--- a/src/derived_systems/poincare/poincaremap.jl
+++ b/src/derived_systems/poincare/poincaremap.jl
@@ -19,7 +19,7 @@ A discrete time dynamical system that produces iterations over the Poincaré map
 of the given continuous time `ds`. This map is defined as the sequence of points on the
 Poincaré surface of section, which is defined by the `plane` argument.
 
-Iterating `pmap` also mutates `ds` which is referrenced in `pmap`.
+Iterating `pmap` also mutates `ds` which is referenced in `pmap`.
 
 See also [`StroboscopicMap`](@ref), [`poincaresos`](@ref).
 
@@ -151,7 +151,7 @@ additional_details(pmap::PoincareMap) = [
 # Extensions
 ###########################################################################################
 for f in (
-        :initial_state, :current_parameters, :initial_parameters, :referrenced_sciml_prob,
+        :initial_state, :current_parameters, :initial_parameters, :referenced_sciml_prob,
         :dynamic_rule, :(SciMLBase.isinplace), :(StateSpaceSets.dimension),
     )
     @eval $(f)(pmap::PoincareMap, args...) = $(f)(pmap.ds, args...)

--- a/src/derived_systems/projected_system.jl
+++ b/src/derived_systems/projected_system.jl
@@ -95,7 +95,7 @@ additional_details(prods::ProjectedDynamicalSystem) = [
 # Everything besides `dimension`, `current/initia_state` and `reinit!` is propagated!
 for f in (
         :(SciMLBase.isinplace), :current_time, :initial_time, :isdiscretetime,
-        :referrenced_sciml_prob, :successful_step,
+        :referenced_sciml_prob, :successful_step,
         :current_parameters, :initial_parameters, :isdeterministic, :dynamic_rule,
     )
     @eval $(f)(prods::ProjectedDynamicalSystem, args...; kw...) =

--- a/src/derived_systems/stroboscopic_map.jl
+++ b/src/derived_systems/stroboscopic_map.jl
@@ -52,7 +52,7 @@ set_period!(smap::StroboscopicMap, T) = (smap.period = T)
 ###########################################################################################
 for f in (
         :current_state, :initial_state, :current_parameters, :initial_parameters,
-        :dynamic_rule, :set_state!, :successful_step, :referrenced_sciml_prob,
+        :dynamic_rule, :set_state!, :successful_step, :referenced_sciml_prob,
         :(SciMLBase.isinplace), :(StateSpaceSets.dimension),
     )
     @eval $(f)(smap::StroboscopicMap, args...) = $(f)(smap.ds, args...)

--- a/test/stochastic.jl
+++ b/test/stochastic.jl
@@ -108,8 +108,8 @@ end
         corr_alt = CoupledSDEs(f, zeros(2); g = g, noise_prototype = zeros(2, 2))
         @test corr.noise_type == corr_alt.noise_type
         @test all(
-            DynamicalSystemsBase.referrenced_sciml_prob(corr).g(zeros(2), (), 0.0) .==
-                DynamicalSystemsBase.referrenced_sciml_prob(corr_alt).g(zeros(2), (), 0.0)
+            DynamicalSystemsBase.referenced_sciml_prob(corr).g(zeros(2), (), 0.0) .==
+                DynamicalSystemsBase.referenced_sciml_prob(corr_alt).g(zeros(2), (), 0.0)
         )
     end
 


### PR DESCRIPTION
Finishes #236, applying @Datseris's review feedback.

- Mass-rename `referrenced` -> `referenced` across src, tests, docs and CHANGELOG, including comments and error messages (also fixes the typos `referrencing`, `referrence`).
- Export `referenced_sciml_prob` (previously unexported) and give it a docstring.
- Add deprecations in `src/deprecations.jl` for the misspelled names so downstream code keeps working with a deprecation warning:
  - `referrenced_sciml_prob` -> `referenced_sciml_prob`
  - `referrenced_sciml_model` -> `referenced_sciml_model`
  - `has_referrenced_model` -> `has_referenced_model` (non-exported form)
- Bump version 3.17.0 -> 3.18.0 and add a v3.18 changelog entry.

Closes #236.